### PR TITLE
Update to target v2 Terminal.Gui

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,4 +13,4 @@ jobs:
         run: dotnet pack
       - name: Publish to Nuget
         if: contains(github.ref, 'refs/tags/v')
-        run: dotnet nuget push ./bin/Debug/Terminal.Gui.templates.$(fgrep \<PackageVersion\> ./Terminal.Gui.templates.csproj | grep -oEi '[0-9.]+').nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ./bin/Debug/Terminal.Gui.templates.$(fgrep \<PackageVersion\> ./Terminal.Gui.templates.csproj | grep -oEi '[0-9a-zA-Z.-]+').nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json

--- a/Terminal.Gui.templates.csproj
+++ b/Terminal.Gui.templates.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.0.3</PackageVersion>
+    <PackageVersion>2.0.0-v2-develop.2203</PackageVersion>
     <PackageId>Terminal.gui.templates</PackageId>
     <Title>Terminal.Gui templates</Title>
     <Authors>Thomas Nind</Authors>
     <Description>Templates to use when creating an application for Terminal.Gui.</Description>
     <PackageTags>dotnet-new;templates;csharp;terminal;c#;gui;template;consol</PackageTags>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageProjectUrl>https://github.com/gui-cs/Terminal.Gui.templates</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -16,13 +16,15 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>
    <PackageReleaseNotes>
-    v1.0.3
-      - Added Title to window showing quit shortcut
-    v1.0.2
-      - Renamed package Terminal.Gui.templates
-    v1.0.1
-      - Added README.md to package
-      - Changed Terminal.Gui package dependency to be 1.* instead of explicitly 1.7.2
+	   2.0.0-v2-develop.2203
+       - Update for version 2 of Terminal.Gui (latest Terminal Gui Designer compatible edition)
+	   v1.0.3
+	   - Added Title to window showing quit shortcut
+	   v1.0.2
+	   - Renamed package Terminal.Gui.templates
+	   v1.0.1
+	   - Added README.md to package
+	   - Changed Terminal.Gui package dependency to be 1.* instead of explicitly 1.7.2
    </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/templates/basic/MyGuiCsProject.csproj
+++ b/templates/basic/MyGuiCsProject.csproj
@@ -8,8 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Terminal.Gui" Version="2.0.0-*"/>
-	  <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
+	  <PackageReference Include="Terminal.Gui" Version="2.0.0-v2-develop.2203" />
   </ItemGroup>
 
 </Project>

--- a/templates/basic/MyGuiCsProject.csproj
+++ b/templates/basic/MyGuiCsProject.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Terminal.Gui" Version="1.*" />
+	  <PackageReference Include="Terminal.Gui" Version="2.0.0-*"/>
+	  <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
   </ItemGroup>
 
 </Project>

--- a/templates/basic/MyView.Designer.cs
+++ b/templates/basic/MyView.Designer.cs
@@ -28,25 +28,19 @@ namespace MyGuiCsProject {
             this.Y = 0;
             this.Modal = false;
             this.Text = "";
-            this.Border.BorderStyle = Terminal.Gui.BorderStyle.Single;
-            this.Border.Effect3D = false;
-            this.Border.DrawMarginFrame = true;
-            this.TextAlignment = Terminal.Gui.TextAlignment.Left;
             this.Title = "Press Ctrl+Q to quit";
-            this.label1.Width = 4;
+            this.label1.Width = Dim.Auto();
             this.label1.Height = 1;
             this.label1.X = Pos.Center();
             this.label1.Y = Pos.Center();
             this.label1.Data = "label1";
             this.label1.Text = "Hello World";
-            this.label1.TextAlignment = Terminal.Gui.TextAlignment.Left;
             this.Add(this.label1);
-            this.button1.Width = 12;
+            this.button1.Width = Dim.Auto();
             this.button1.X = Pos.Center();
             this.button1.Y = Pos.Center() + 1;
             this.button1.Data = "button1";
             this.button1.Text = "Click Me";
-            this.button1.TextAlignment = Terminal.Gui.TextAlignment.Centered;
             this.button1.IsDefault = false;
             this.Add(this.button1);
         }

--- a/templates/basic/MyView.cs
+++ b/templates/basic/MyView.cs
@@ -15,7 +15,7 @@ namespace MyGuiCsProject{
         
         public MyView() {
             InitializeComponent();
-            button1.Clicked += () => MessageBox.Query("Hello", "Hello There!", "Ok");
+            button1.Accept += (s,e) => MessageBox.Query("Hello", "Hello There!", "Ok");
         }
     }
 }

--- a/templates/basic/MyView.cs
+++ b/templates/basic/MyView.cs
@@ -15,7 +15,7 @@ namespace MyGuiCsProject{
         
         public MyView() {
             InitializeComponent();
-            button1.Accept += (s,e) => MessageBox.Query("Hello", "Hello There!", "Ok");
+            button1.Accept += (s, e) => MessageBox.Query("Hello", "Hello There!", "Ok");
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/gui-cs/Terminal.Gui/issues/3746


- Now targets dotnet 8
- Now targets v2 develop package that matches TGD compatibility (2203)

I looked into flexible targeting like v1 i.e. 
`<PackageReference Include="Terminal.Gui" Version="2.0.0-*"/>`

But there were 2 problems

- This seemed to update to `Terminal.Gui/2.0.0-v2-release.1809` for some reason - I guess because naming convention has changed in releases
- If we are flexible targetting we may end up with a broken template because of backwards compatibility breaking changes in alpha
- Its nice to target the same version as TGD for consistency and stability