### PR TITLE
Relaunch as the AI-agent-first on-ramp to Terminal.Gui v2 (unfreeze + modernize + embed agent guidance)

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,12 +1,17 @@
-name: Auto-publish on Terminal.Gui release
+name: Auto-publish on new Terminal.Gui release
 
 on:
+  # Preferred: Terminal.Gui dispatches this when it ships a release.
   repository_dispatch:
     types: [terminal-gui-v2-released]
+  # Self-contained safety net: also poll NuGet daily so this can't silently freeze
+  # if the dispatch contract ever breaks (which is how it got stuck on 2.0.0-alpha.4309).
+  schedule:
+    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       skip_delay:
-        description: 'Skip the 15-minute delay (for testing)'
+        description: 'Skip the NuGet-indexing delay (for testing)'
         required: false
         type: boolean
         default: false
@@ -16,88 +21,74 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required to push commits and tags
-    
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT_AUTO_PUBLISH_TOKEN }}
-      
+
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-      
+
       - name: Set up .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.x'
-      
+
       - name: Wait for NuGet indexing
-        if: ${{ !inputs.skip_delay }}
+        if: ${{ github.event_name == 'repository_dispatch' && !inputs.skip_delay }}
         run: |
           echo "Waiting 15 minutes for NuGet to index the new package..."
           sleep 900
-      
-      - name: Get latest Terminal.Gui pre-release version
+
+      - name: Get latest stable Terminal.Gui version
         id: get_version
         run: |
+          # Latest STABLE Terminal.Gui: drop every pre-release ('-...') and order by real semver.
+          # The old logic matched only -alpha/-beta and sorted by the last dotted field, so it
+          # permanently re-selected 2.0.0-alpha.4309 and froze the package.
           url="https://api.nuget.org/v3-flatcontainer/terminal.gui/index.json"
-          # Support both alpha and beta releases
-          latest_version=$(curl -s $url | jq -r '.versions[]' | grep -E -- '-(alpha|beta)\.' | awk -F'.' '{print $NF, $0}' | sort -n | tail -n 1 | cut -d' ' -f2-)
-          
+          # select(...) keeps only stable versions (no '-' pre-release suffix); sort -V = semver order.
+          latest_version=$(curl -s "$url" | jq -r '.versions[] | select(contains("-") | not)' | sort -V | tail -n 1)
           if [ -z "$latest_version" ]; then
-            echo "Error: No alpha or beta version found"
+            echo "::error::Could not resolve a stable Terminal.Gui version from NuGet."
             exit 1
           fi
-          
-          echo "Found latest version: $latest_version"
-          echo "latest_prerelease=$latest_version" >> $GITHUB_OUTPUT
-      
-      - name: Update Terminal.Gui dependency in template
+          echo "Latest stable Terminal.Gui: $latest_version"
+          echo "latest_version=$latest_version" >> "$GITHUB_OUTPUT"
+
+      - name: Update Terminal.Gui dependency in templates
         run: |
-          sed -i 's/\(<PackageVersion>\)[^<]*\(<\/PackageVersion>\)/\1${{ steps.get_version.outputs.latest_prerelease }}\2/' Terminal.Gui.templates.csproj
-          sed -i 's/\(<PackageReference Include="Terminal.Gui" Version="\)[^"]*\(".*\)/\1${{ steps.get_version.outputs.latest_prerelease }}\2/' templates/tui-simple/tui-simple.csproj
-          sed -i 's/\(<PackageReference Include="Terminal.Gui" Version="\)[^"]*\(".*\)/\1${{ steps.get_version.outputs.latest_prerelease }}\2/' templates/tui-designer/tui-designer.csproj
-      
+          v='${{ steps.get_version.outputs.latest_version }}'
+          sed -i "s|\(<PackageVersion>\)[^<]*\(</PackageVersion>\)|\1$v\2|" Terminal.Gui.templates.csproj
+          sed -i "s|\(<PackageReference Include=\"Terminal.Gui\" Version=\"\)[^\"]*\(\".*\)|\1$v\2|" templates/tui-simple/tui-simple.csproj
+          sed -i "s|\(<PackageReference Include=\"Terminal.Gui\" Version=\"\)[^\"]*\(\".*\)|\1$v\2|" templates/tui-designer/tui-designer.csproj
+
       - name: Commit changes
         run: |
           git add .
           if git diff --staged --quiet; then
-            echo "No changes to commit"
+            echo "Already up to date with Terminal.Gui ${{ steps.get_version.outputs.latest_version }}; nothing to do."
           else
-            git commit -m "Auto-update to Terminal.Gui ${{ steps.get_version.outputs.latest_prerelease }}"
-            echo "Changes committed"
+            git commit -m "Auto-update to Terminal.Gui ${{ steps.get_version.outputs.latest_version }}"
+            echo "committed=true" >> "$GITHUB_ENV"
           fi
-      
+
       - name: Create and push tag
         run: |
-          TAG="v${{ steps.get_version.outputs.latest_prerelease }}"
-          
-          # Check if tag already exists locally
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists locally, checking remote..."
-          fi
-          
-          # Check if tag exists on remote
+          TAG="v${{ steps.get_version.outputs.latest_version }}"
+
           if git ls-remote --tags origin | grep -q "refs/tags/$TAG$"; then
-            echo "Tag $TAG already exists on remote, skipping publish"
+            echo "Tag $TAG already exists on remote; nothing to publish."
             exit 0
           fi
-          
-          # Create and push tag
-          git tag "$TAG"
-          echo "Created tag: $TAG"
-          
-          # Push commits if there are any
-          if ! git diff --quiet HEAD origin/main 2>/dev/null; then
-            echo "Pushing commits to main..."
+
+          if [ "${committed:-}" = "true" ]; then
             git push origin HEAD:main
-          else
-            echo "No commits to push to main"
           fi
-          
-          # Push tag
+
+          git tag "$TAG"
           git push origin "$TAG"
-          
-          echo "Successfully pushed tag: $TAG"
-          echo "This will trigger the build workflow to publish to NuGet"
+          echo "Pushed $TAG — this triggers the build workflow to publish to NuGet."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,50 +11,61 @@ jobs:
         job: [package-template, test-template]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.x'
 
-      - name: Get latest Terminal.Gui pre-release version
+      - name: Get latest stable Terminal.Gui version
         id: get_version
         run: |
+          # Pick the latest STABLE Terminal.Gui from NuGet.
+          # NOTE: the old selector matched only -alpha/-beta and sorted by the LAST dotted
+          # field, so it re-picked 2.0.0-alpha.4309 (build 4309) forever and froze this repo.
+          # Filter out every pre-release (anything with a '-') and sort with real semver order.
           url="https://api.nuget.org/v3-flatcontainer/terminal.gui/index.json"
-          # Support both alpha and beta releases
-          latest_version=$(curl -s $url | jq -r '.versions[]' | grep -E -- '-(alpha|beta)\.' | awk -F'.' '{print $NF, $0}' | sort -n | tail -n 1 | cut -d' ' -f2-)
-          echo "latest_prerelease=$latest_version" >> $GITHUB_OUTPUT
+          # select(...) keeps only stable versions (no '-' pre-release suffix); sort -V = semver order.
+          latest_version=$(curl -s "$url" | jq -r '.versions[] | select(contains("-") | not)' | sort -V | tail -n 1)
+          if [ -z "$latest_version" ]; then
+            echo "::error::Could not resolve a stable Terminal.Gui version from NuGet."
+            exit 1
+          fi
+          echo "Latest stable Terminal.Gui: $latest_version"
+          echo "latest_version=$latest_version" >> "$GITHUB_OUTPUT"
 
-      - name: Update Terminal.Gui dependency in template
+      - name: Update Terminal.Gui dependency in templates
         run: |
-          sed -i 's/\(<PackageVersion>\)[^<]*\(<\/PackageVersion>\)/\1${{ steps.get_version.outputs.latest_prerelease }}\2/' Terminal.Gui.templates.csproj
-          sed -i 's/\(<PackageReference Include="Terminal.Gui" Version="\)[^"]*\(".*\)/\1${{ steps.get_version.outputs.latest_prerelease }}\2/' templates/tui-simple/tui-simple.csproj
-          sed -i 's/\(<PackageReference Include="Terminal.Gui" Version="\)[^"]*\(".*\)/\1${{ steps.get_version.outputs.latest_prerelease }}\2/' templates/tui-designer/tui-designer.csproj
-          sed -i 's/\(<PackageVersion>\)[^<]*\(<\/PackageVersion>\)/\1${{ steps.get_version.outputs.latest_prerelease }}\2/' Terminal.Gui.templates.csproj
+          v='${{ steps.get_version.outputs.latest_version }}'
+          sed -i "s|\(<PackageVersion>\)[^<]*\(</PackageVersion>\)|\1$v\2|" Terminal.Gui.templates.csproj
+          sed -i "s|\(<PackageReference Include=\"Terminal.Gui\" Version=\"\)[^\"]*\(\".*\)|\1$v\2|" templates/tui-simple/tui-simple.csproj
+          sed -i "s|\(<PackageReference Include=\"Terminal.Gui\" Version=\"\)[^\"]*\(\".*\)|\1$v\2|" templates/tui-designer/tui-designer.csproj
 
       - name: Build and Package Template
         if: matrix.job == 'package-template'
         run: |
-          dotnet restore
-          dotnet list package
-          dotnet pack
+          # Pack only the template package project — NOT the solution (the generated app
+          # csprojs under templates/ are content, not buildable projects of this package).
+          dotnet pack Terminal.Gui.templates.csproj -c Release
 
       - name: Publish to NuGet
         if: matrix.job == 'package-template' && contains(github.ref, 'refs/tags/v')
         run: dotnet nuget push ./bin/Release/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
 
-      - name: Test Template Install and Build
+      - name: Test the template installs, generates, and builds
         if: matrix.job == 'test-template'
         run: |
-          # Install the template locally
-          dotnet new install templates/tui-simple
-
-          # Create a new project from the template
-          mkdir testapp
-          cd testapp
-          dotnet new tui-simple -n myproj
-          cd myproj
-
-          # Build the generated project
-          dotnet build
+          set -euo pipefail
+          # tui-designer is intentionally not tested/packaged yet (designer snapshot needs
+          # regeneration against current Terminal.Gui). Test the packaged template(s).
+          for t in tui-simple; do
+            echo "::group::$t"
+            rm -rf "/tmp/$t-test"
+            dotnet new install "./templates/$t"
+            dotnet new "$t" -n SmokeApp -o "/tmp/$t-test"
+            # Verify the agent guidance is emitted (the whole point of these templates).
+            test -f "/tmp/$t-test/AGENTS.md" || { echo "::error::$t did not emit AGENTS.md"; exit 1; }
+            dotnet build "/tmp/$t-test"
+            echo "::endgroup::"
+          done

--- a/README.md
+++ b/README.md
@@ -1,40 +1,34 @@
-  [![NuGet Badge](https://buildstats.info/nuget/Terminal.gui.templates)](https://www.nuget.org/packages/Terminal.gui.templates/)
+[![NuGet](https://img.shields.io/nuget/v/Terminal.Gui.Templates)](https://www.nuget.org/packages/Terminal.Gui.Templates/)
 
-  # Usage
-  This is a template for creating Terminal.Gui v2 applications using `dotnet new`.
+# Terminal.Gui Templates
 
-  To add this template to those available in `dotnet new` install the NuGet package:
+`dotnet new` templates for building [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) **v2** apps — designed so an **AI coding agent** can scaffold and extend a TUI app correctly. Every generated project ships an **`AGENTS.md`** with the canonical v2 patterns (Terminal.Gui v2 is a complete rewrite, so most online/training-data examples are v1 and won't compile).
 
-  ```
-  dotnet new install Terminal.gui.templates@2.0.0-alpha.*
-  ```
+## Install
 
-  The above will install the latest Terminal.Gui v2 alpha templates. For the stable v1 templates:
+```bash
+dotnet new install Terminal.Gui.Templates
+```
 
-  ```
-  dotnet new install Terminal.gui.templates
-  ```
+This installs the latest templates targeting current stable Terminal.Gui (net10.0).
 
-  ## Creating projects
+## Create a project
 
-  After installing you can use the templates to create new projects:
+### `tui-simple`
 
-  ### tui-simple
+A minimal, agent-ready Terminal.Gui v2 app: a `Window` with a label and a quit button, an embedded `AGENTS.md`/`CLAUDE.md`, and a fully commented `Program.cs`.
 
-  A minimal starter template with a simple window, welcome label, and quit button:
+```bash
+dotnet new tui-simple -n MyApp
+cd MyApp
+dotnet run            # Esc or the Quit button exits
+```
 
-  ```
-  dotnet new tui-simple -n mytuiapp
-  cd mytuiapp
-  dotnet run
-  ```
+Open `MyApp/AGENTS.md` first — it has the canonical minimal app, the v1→v2 corrections table, `Pos`/`Dim` layout, common gotchas, and links to Terminal.Gui's CI-validated docs.
 
-  ### tui-designer
+> **Note:** the previous `tui-designer` template is temporarily not shipped while it's regenerated against current Terminal.Gui — see [#24](https://github.com/gui-cs/Terminal.Gui.templates/issues/24).
 
-  A template optimized for use with [Terminal.Gui Designer](https://github.com/gui-cs/TerminalGuiDesigner):
-
-  ```
-  dotnet new tui-designer -n mytuiapp
-  cd mytuiapp
-  dotnet run
-  ```
+## Links
+- Terminal.Gui: https://github.com/gui-cs/Terminal.Gui
+- Getting started: https://gui-cs.github.io/Terminal.Gui/
+- Relaunch plan: [#22](https://github.com/gui-cs/Terminal.Gui.templates/issues/22)

--- a/Terminal.Gui.templates.csproj
+++ b/Terminal.Gui.templates.csproj
@@ -2,38 +2,35 @@
 
 	<PropertyGroup>
 		<PackageType>Template</PackageType>
-		<PackageVersion>2.0.0-alpha.4309</PackageVersion>
-		<PackageId>Terminal.gui.templates</PackageId>
+		<PackageVersion>2.4.8</PackageVersion>
+		<PackageId>Terminal.Gui.Templates</PackageId>
 		<Title>Terminal.Gui templates</Title>
-		<Authors>Thomas Nind</Authors>
-		<Description>Templates to use when creating an application for Terminal.Gui v2.</Description>
-		<PackageTags>dotnet-new;templates;csharp;terminal;c#;gui;template;consol</PackageTags>
+		<Authors>gui-cs</Authors>
+		<Description>AI-agent-ready `dotnet new` templates for building Terminal.Gui v2 apps (net10.0). Generated projects ship embedded AGENTS.md guidance with the canonical v2 patterns.</Description>
+		<PackageTags>dotnet-new;templates;template;terminal;tui;gui;console;csharp;terminal.gui;ai-agents</PackageTags>
 		<TargetFramework>net10.0</TargetFramework>
 		<PackageProjectUrl>https://github.com/gui-cs/Terminal.Gui.templates</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<IncludeContentInPack>true</IncludeContentInPack>
 		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
 		<ContentTargetFolders>content</ContentTargetFolders>
 		<PackageReleaseNotes>
-			2.0.0-v2-develop.4766
-			- Update for version 2 of Terminal.Gui
-			2.0.0-v2-develop.4519
-			- Update for version 2 of Terminal.Gui
-			2.0.0-v2-develop.2203
-			- Update for version 2 of Terminal.Gui (latest Terminal Gui Designer compatible edition)
-			v1.0.3
-			- Added Title to window showing quit shortcut
-			v1.0.2
-			- Renamed package Terminal.Gui.templates
-			v1.0.1
-			- Added README.md to package
-			- Changed Terminal.Gui package dependency to be 1.* instead of explicitly 1.7.2
+			2.4.x
+			- Relaunch as the AI-agent-first on-ramp to Terminal.Gui v2.
+			- Re-target current stable Terminal.Gui (was frozen on 2.0.0-alpha.4309 by a broken version selector).
+			- tui-simple: generated projects now ship AGENTS.md + CLAUDE.md with the canonical v2 patterns,
+			  v1-&gt;v2 corrections, Pos/Dim layout, and common-pitfall gotchas; Program.cs is fully commented.
+			- tui-designer is temporarily not packaged pending regeneration against current Terminal.Gui
+			  (its TerminalGuiDesigner snapshot no longer compiles). Tracked separately.
 		</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" />
+		<!-- tui-designer is excluded until its designer-generated code is regenerated against current
+		     Terminal.Gui (the snapshot references the removed View.ShadowStyle API). See follow-up issue. -->
+		<Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**;templates\tui-designer\**" />
 		<Compile Remove="**\*" />
 		<None Remove="templates\**\bin\**" />
 		<None Remove="templates\**\obj\**" />

--- a/templates/tui-designer/tui-designer.csproj
+++ b/templates/tui-designer/tui-designer.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Terminal.Gui" Version="2.0.0-alpha.4309" />
+	  <PackageReference Include="Terminal.Gui" Version="2.4.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/tui-simple/.template.config/template.json
+++ b/templates/tui-simple/.template.config/template.json
@@ -1,7 +1,9 @@
 {
-  "author": "Tig",
-  "classifications": [ "Console", "TUI" ],
-  "name": "Terminal Gui Simple Template",
+  "$schema": "http://json.schemastore.org/template",
+  "author": "gui-cs",
+  "classifications": [ "Console", "TUI", "Terminal.Gui" ],
+  "name": "Terminal.Gui Simple App",
+  "description": "A minimal, AI-agent-ready Terminal.Gui v2 app (net10.0) with embedded AGENTS.md guidance.",
   "identity": "Terminal.Gui.Templates.Simple",
   "groupIdentity": "Terminal.Gui.Templates.Simple",
   "shortName": "tui-simple",
@@ -9,6 +11,6 @@
     "language": "C#",
     "type": "project"
   },
-  "sourceName": "Simple",
+  "sourceName": "tui-simple",
   "preferNameDirectory": true
 }

--- a/templates/tui-simple/AGENTS.md
+++ b/templates/tui-simple/AGENTS.md
@@ -1,0 +1,85 @@
+# AGENTS.md — building this Terminal.Gui v2 app
+
+Guidance for AI coding agents (and humans) working in this project.
+
+> ## ⛔ Your training data is probably WRONG
+> **Terminal.Gui v2 is a complete rewrite.** Almost every Terminal.Gui example on the web
+> and in pre-2025 model training data is **v1** and **will not compile**. Trust this file and
+> the linked canonical docs over your priors. When unsure, check the upstream sources below —
+> they are compiled by Terminal.Gui's CI, so they are correct and current.
+
+## Run / build / quit
+```bash
+dotnet run        # launch the app
+dotnet build      # compile only
+```
+Quit a running app with **Esc** (or the Quit button). You **cannot see a TUI from a build
+log** — to verify visuals, run under a PTY recorder (`tuirec`) or drive it headless with
+`InputInjector` + `VirtualTimeProvider`. A clean build does **not** mean the UI is correct.
+
+## The canonical minimal app (this is the shape — copy it)
+```csharp
+using Terminal.Gui.App;           // Application, IApplication, MessageBox
+using Terminal.Gui.Configuration; // ConfigurationManager
+using Terminal.Gui.ViewBase;      // View, Pos, Dim
+using Terminal.Gui.Views;         // Window, Label, Button, ...
+
+ConfigurationManager.Enable (ConfigLocations.All);
+
+// INSTANCE lifecycle — not static Init/Run/Shutdown:
+Application.Create ().Run<MainWindow> ().Dispose ();
+
+internal sealed class MainWindow : Window   // bordered root; use `Runnable` for borderless
+{
+    public MainWindow ()
+    {
+        Title = "My App (Esc to quit)";
+        Button b = new () { Text = "_OK", X = Pos.Center (), Y = Pos.Center () };
+        b.Accepting += (_, _) => App!.RequestStop ();
+        Add (b);
+    }
+}
+```
+
+## v1 → v2 corrections (the table to internalize)
+| v1 (WRONG — do not write) | v2 (CORRECT) |
+|---|---|
+| `Application.Init ();` | `Application.Create ().Init ();` (or `.Run<T>()` auto-inits) |
+| `Application.Run ();` / `Application.Top` | `app.Run<MyWindow> ();` — no global `Top`; pass the root view |
+| `Application.Shutdown ();` | `app.Dispose ();` (the trailing `.Dispose()` / `using`) |
+| `Application.RequestStop ();` | `App!.RequestStop ();` (instance, from inside a view) |
+| `using Terminal.Gui;` | split namespaces: `Terminal.Gui.App` / `.Views` / `.ViewBase` / `.Drawing` / `.Input` / `.Configuration` |
+| `new Toplevel ()` | subclass `Runnable`, or use `Window` |
+| `new Button ("OK")` | `new Button { Text = "OK" }` (object initializers; no positional ctors) |
+| `button.Clicked += …` | `button.Accepting += (_, _) => …;` (no `Clicked` in v2) |
+| `view.Bounds` | `view.Viewport` |
+| `LayoutStyle.Computed` | removed — layout is always declarative via `Pos`/`Dim` |
+| `new RadioGroup (…)` | `new OptionSelector { … }` |
+| `Colors.ColorSchemes["x"]` | `Schemes.Resolve ("x")` |
+
+## Layout: `Pos` / `Dim` (don't hardcode coordinates)
+- `X`/`Y`: `Pos.Center ()`, `Pos.Right (otherView)`, `Pos.Percent (25)`, `Pos.AnchorEnd ()`, or an `int`.
+- `Width`/`Height`: `Dim.Fill ()`, `Dim.Fill (1)`, `Dim.Auto ()`, `Dim.Percent (50)`, or an `int`.
+
+## ⚠️ Gotchas agents get wrong (verified against Terminal.Gui source)
+1. **Dialog/MessageBox button order = the default.** The **last button added is the default**
+   (Enter-activated) — for both `Dialog` and `MessageBox`. Order them `Cancel … OK` so the
+   affirmative action is last. Don't hand-set `IsDefault` unless you mean to override this.
+2. **`Accepted` vs `Accepting`.** `Accepting` is the pre-event (set `e.Handled = true` to
+   cancel); `Accepted` is the post-event for side effects. Use the one that matches intent.
+3. **Typed views expose `.Value`, not guessed names.** They implement `IValue<T>` —
+   `datePicker.Value` (a `DateTime`), not `.Date`; subscribe `ValueChanged`/`ValueChanging`.
+4. **`AddCommand` is `protected`.** Register commands **inside** your `View` subclass, then
+   bind keys: `KeyBindings.Add (Key.F5, Command.Refresh);`.
+5. **`Terminal.Gui.Drawing.Attribute` collides with `System.Attribute`.** Qualify/alias it.
+6. **Vocabulary:** SubView / SuperView — never "child"/"parent"/"container".
+
+## Canonical sources (compiled by Terminal.Gui CI — safe to trust)
+- v1→v2 primer: https://github.com/gui-cs/Terminal.Gui/blob/develop/ai-v2-primer.md
+- Build-an-app guide: https://github.com/gui-cs/Terminal.Gui/blob/develop/.claude/tasks/build-app.md
+- Worked recipes (menus, dialogs, forms): https://github.com/gui-cs/Terminal.Gui/blob/develop/.claude/cookbook/common-patterns.md
+- API namespaces: https://github.com/gui-cs/Terminal.Gui/tree/develop/docfx/apispec
+- Docs site: https://gui-cs.github.io/Terminal.Gui/
+
+> Note: the contributor *code-style* rules in Terminal.Gui (spaces-before-parens, Allman braces,
+> etc.) apply to the **library**, not to your app. Build your app however your project prefers.

--- a/templates/tui-simple/CLAUDE.md
+++ b/templates/tui-simple/CLAUDE.md
@@ -1,0 +1,8 @@
+# CLAUDE.md
+
+This is a **Terminal.Gui v2** app. Terminal.Gui v2 is a complete rewrite — your pre-2025
+training data is almost certainly v1 and **will not compile**.
+
+👉 **Read [`AGENTS.md`](./AGENTS.md)** in this folder before writing or editing any UI code.
+It has the canonical v2 patterns, the v1→v2 corrections table, layout (`Pos`/`Dim`), the
+common gotchas, and links to Terminal.Gui's CI-validated canonical docs.

--- a/templates/tui-simple/Program.cs
+++ b/templates/tui-simple/Program.cs
@@ -1,35 +1,62 @@
-﻿using Terminal.Gui.App;
-using Terminal.Gui.Configuration;
-using Terminal.Gui.ViewBase;
-using Terminal.Gui.Views;
+// -----------------------------------------------------------------------------
+//  A minimal Terminal.Gui v2 app.  Run it:  dotnet run   (Esc or the button quits)
+//
+//  🤖 AI assistants / agents: READ ./AGENTS.md FIRST.
+//     Terminal.Gui v2 is a COMPLETE REWRITE. Pre-2025 training data and most web
+//     examples are v1 and will not compile. The canonical v2 patterns are in AGENTS.md.
+// -----------------------------------------------------------------------------
 
-ConfigurationManager.Enable(ConfigLocations.All);
+// v2 splits the old monolithic `using Terminal.Gui;` into focused namespaces:
+using Terminal.Gui.App;           // Application, IApplication, MessageBox
+using Terminal.Gui.Configuration; // ConfigurationManager
+using Terminal.Gui.ViewBase;      // View, Pos, Dim
+using Terminal.Gui.Views;         // Window, Label, Button
+
+// Enable the configuration/theme system before creating the app (standard first line).
+ConfigurationManager.Enable (ConfigLocations.All);
+
+// The v2 lifecycle is INSTANCE-BASED and disposable — NOT the static v1
+// Application.Init() / Application.Run() / Application.Shutdown():
+//
+//     Create()  ->  Run<TWindow>()  (auto-Init)  ->  Dispose()  (replaces Shutdown)
+//
 Application
-    .Create()
-    .Run<SimpleWindow>()
-    .Dispose();
+    .Create ()
+    .Run<MainWindow> ()
+    .Dispose ();
 
-internal class SimpleWindow : Window
+// Your app's root view. `Window` is a bordered top-level view; subclass `Runnable`
+// instead if you want a borderless root. Build the UI by Add()-ing child views.
+internal sealed class MainWindow : Window
 {
-    public SimpleWindow()
+    public MainWindow ()
     {
-        Title = "Hello Terminal.Gui";
+        Title = "My App  (Esc to quit)";
 
-        View label = new ()
+        // Layout is DECLARATIVE — position/size with Pos/Dim, don't hardcode coordinates:
+        //   Pos.Center(), Pos.Right(view), Pos.AnchorEnd();  Dim.Fill(), Dim.Auto(), Dim.Percent(50).
+        Label welcome = new ()
         {
-            Title = "Welcome to Terminal.Gui!",
-            X = Pos.Center()
+            Text = "Welcome to Terminal.Gui v2!",
+            X = Pos.Center (),
+            Y = 1
         };
 
-        Button button = new ()
+        Button quit = new ()
         {
-            Title = "_Click Me to Quit (or press Esc)",
-            X = Pos.Center(),
-            Y = Pos.Center()
+            Text = "_Quit",        // the leading _ defines the hotkey (Alt+Q)
+            X = Pos.Center (),
+            Y = Pos.Center ()
         };
 
-        button.Accepting += (_, _) => App!.RequestStop();
+        // v2 has NO `Clicked` event. A view raises `Accepting` when the user activates it
+        // (Enter / click / hotkey); set e.Handled = true to cancel. `Accepted` is the
+        // post-activation variant — see AGENTS.md (#Events) for which to use when.
+        // `App!` is the running IApplication, reachable from any view in the tree.
+        quit.Accepting += (_, _) => App!.RequestStop ();
 
-        Add(label, button);
+        Add (welcome, quit);
+
+        // 👉 Add your views here. See AGENTS.md for canonical patterns + common pitfalls.
     }
 }

--- a/templates/tui-simple/README.md
+++ b/templates/tui-simple/README.md
@@ -1,30 +1,27 @@
-# Terminal.Gui Simple Template
+# My Terminal.Gui App
 
-A minimal starter template for building Terminal User Interface (TUI) applications with [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) v2.
-
-## Usage
-
-Install the template:
+A minimal Terminal User Interface (TUI) app built with [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) **v2**.
 
 ```bash
-dotnet new install Terminal.gui.templates@2.0.0-alpha.*
+dotnet run        # launch (Esc or the Quit button exits)
+dotnet build      # compile only
 ```
 
-Create a new project:
+## Project layout
+| File | Purpose |
+|---|---|
+| `Program.cs` | App entry point + the root `MainWindow` view. Add your views here. |
+| `AGENTS.md` | **Canonical Terminal.Gui v2 patterns + gotchas for AI agents and humans.** Start here. |
+| `CLAUDE.md` | Thin pointer to `AGENTS.md` for Claude / Claude Code. |
+| `*.csproj` | Targets `net10.0`, references `Terminal.Gui`. |
 
-```bash
-dotnet new tui-simple -n MyApp
-cd MyApp
-dotnet run
-```
+## Building with an AI agent?
+Terminal.Gui v2 is a complete rewrite — most examples online (and in model training data)
+are **v1 and won't compile**. **Read [`AGENTS.md`](./AGENTS.md) first**: it has the canonical
+minimal app, the v1→v2 corrections table, `Pos`/`Dim` layout, the common pitfalls, and links
+to Terminal.Gui's CI-validated docs.
 
-## What's Included
-
-- A simple `Window` with a welcome label and a quit button
-- Pre-configured Terminal.Gui v2 package reference
-- Modern C# with nullable reference types and implicit usings
-
-## Learn More
-
-- [Terminal.Gui Documentation](https://gui-cs.github.io/Terminal.GuiV2Docs/)
-- [Terminal.Gui GitHub](https://github.com/gui-cs/Terminal.Gui)
+## Learn more
+- Getting started: https://gui-cs.github.io/Terminal.Gui/
+- Repository & samples: https://github.com/gui-cs/Terminal.Gui
+- v1→v2 primer: https://github.com/gui-cs/Terminal.Gui/blob/develop/ai-v2-primer.md

--- a/templates/tui-simple/tui-simple.csproj
+++ b/templates/tui-simple/tui-simple.csproj
@@ -6,18 +6,10 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Terminal.Gui" Version="2.0.0-alpha.4309" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
+    <PackageReference Include="Terminal.Gui" Version="2.4.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Implements the first, self-contained slice of the plan in #22. **Unfreezes the package, modernizes `tui-simple` to current stable TG, and makes every generated project teach an AI agent the canonical v2 patterns.**

## Why
- 🔴 **Frozen.** The version selector matched only `-alpha`/`-beta` and sorted by the *last dotted field*, so it re-picked `2.0.0-alpha.4309` (build 4309) forever. TG is now **stable 2.4.8** (net10.0).
- 🟠 **No agent guidance.** Generated projects shipped nothing to orient an agent, and `Program.cs` taught the non-canonical `Window`+side-effect pattern.

## What changed
**Unfreeze + modernize**
- Fix the NuGet selector → latest **stable** TG (`jq 'select(contains("-")|not)' | sort -V`) in `build.yml` + `auto-publish.yml`; add a **daily `schedule`** so it can't silently re-freeze if TG's dispatch ever breaks.
- Re-pin generated apps to **Terminal.Gui 2.4.8** / net10.0; bump actions to v4; pack only the package project; CI now **installs → `dotnet new` → builds** the template and asserts `AGENTS.md` ships.

**Agent-first `tui-simple`**
- Generated projects now ship **`AGENTS.md`** (distilled canonical v2 patterns: instance lifecycle, the v1→v2 corrections table, `Pos`/`Dim`, and the verified gotchas incl. the dialog **last-button-is-default** rule) + a **`CLAUDE.md`** pointer — linking back to TG's CI-validated canonical docs rather than duplicating them.
- `Program.cs` rewritten **fully commented** around the canonical idioms, with an "add your views here" anchor.
- `sourceName` fixed so `-n MyApp` renames the csproj cleanly; dropped NuGet-packaging cruft from the app csproj; agent-oriented README; metadata cleanup (author, tags, docs domain, **`PackageId` casing → `Terminal.Gui.Templates`**).

## Verified locally
`dotnet pack` → install the nupkg → `dotnet new tui-simple -n FromPkg` → **builds 0 errors** against TG 2.4.8; `AGENTS.md`/`CLAUDE.md` emitted; csproj renamed.

## Scope note — `tui-designer` excluded (for now)
Its TerminalGuiDesigner-generated `MyView.Designer.cs` references the **removed `View.ShadowStyle` API** (now `ShadowStyles`, and moved onto the `Margin` adornment) and no longer compiles against current TG. Hand-patching auto-generated designer code is the wrong fix — it needs the designer **tool** to regenerate (which an agent can't drive) and will re-drift each release. So it's excluded from the package and CI here, tracked as a follow-up (regenerate, replace with a hand-coded agent-friendly equivalent, or drop).

## Follow-ups (from #22, not in this PR)
`--with-tests` (headless red-green loop), a flagship `tui` template, richer `template.json` symbols, generating `.cursorrules`/`.aider.md`, and the upstream TG guidance reconciliation in gui-cs/Terminal.Gui#5525.

Refs #22, gui-cs/Terminal.Gui#5525