### PR TITLE
Phase 2: add flagship 'tui' template (menu + status bar + interactive content)

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -63,8 +63,11 @@ jobs:
         run: |
           v='${{ steps.get_version.outputs.latest_version }}'
           sed -i "s|\(<PackageVersion>\)[^<]*\(</PackageVersion>\)|\1$v\2|" Terminal.Gui.templates.csproj
-          sed -i "s|\(<PackageReference Include=\"Terminal.Gui\" Version=\"\)[^\"]*\(\".*\)|\1$v\2|" templates/tui-simple/tui-simple.csproj
-          sed -i "s|\(<PackageReference Include=\"Terminal.Gui\" Version=\"\)[^\"]*\(\".*\)|\1$v\2|" templates/tui-designer/tui-designer.csproj
+          # Bump the Terminal.Gui reference in EVERY template csproj (so new templates are
+          # covered automatically — no per-template edits needed here).
+          for proj in templates/*/*.csproj; do
+            sed -i "s|\(<PackageReference Include=\"Terminal.Gui\" Version=\"\)[^\"]*\(\".*\)|\1$v\2|" "$proj"
+          done
 
       - name: Commit changes
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           set -euo pipefail
           # tui-designer is intentionally not tested/packaged yet (designer snapshot needs
           # regeneration against current Terminal.Gui). Test the packaged template(s).
-          for t in tui-simple; do
+          for t in tui-simple tui; do
             echo "::group::$t"
             rm -rf "/tmp/$t-test"
             dotnet new install "./templates/$t"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,11 @@ jobs:
         run: |
           v='${{ steps.get_version.outputs.latest_version }}'
           sed -i "s|\(<PackageVersion>\)[^<]*\(</PackageVersion>\)|\1$v\2|" Terminal.Gui.templates.csproj
-          sed -i "s|\(<PackageReference Include=\"Terminal.Gui\" Version=\"\)[^\"]*\(\".*\)|\1$v\2|" templates/tui-simple/tui-simple.csproj
-          sed -i "s|\(<PackageReference Include=\"Terminal.Gui\" Version=\"\)[^\"]*\(\".*\)|\1$v\2|" templates/tui-designer/tui-designer.csproj
+          # Bump the Terminal.Gui reference in EVERY template csproj (so new templates are
+          # covered automatically — no per-template edits needed here).
+          for proj in templates/*/*.csproj; do
+            sed -i "s|\(<PackageReference Include=\"Terminal.Gui\" Version=\"\)[^\"]*\(\".*\)|\1$v\2|" "$proj"
+          done
 
       - name: Build and Package Template
         if: matrix.job == 'package-template'

--- a/README.md
+++ b/README.md
@@ -14,17 +14,29 @@ This installs the latest templates targeting current stable Terminal.Gui (net10.
 
 ## Create a project
 
-### `tui-simple`
+Every template emits an `AGENTS.md` + `CLAUDE.md` — open `MyApp/AGENTS.md` first. It has the
+canonical minimal app, the v1→v2 corrections table, `Pos`/`Dim` layout, common gotchas, and
+links to Terminal.Gui's CI-validated docs.
 
-A minimal, agent-ready Terminal.Gui v2 app: a `Window` with a label and a quit button, an embedded `AGENTS.md`/`CLAUDE.md`, and a fully commented `Program.cs`.
+### `tui` — a complete starter (recommended)
+
+A real app to extend: a menu bar, a status bar, and interactive content, wired up with the canonical v2 patterns.
+
+```bash
+dotnet new tui -n MyApp
+cd MyApp
+dotnet run            # File > Quit (or the status bar) exits
+```
+
+### `tui-simple` — the minimal app
+
+The smallest runnable v2 app: a `Window` with a label and a quit button, and a fully commented `Program.cs`.
 
 ```bash
 dotnet new tui-simple -n MyApp
 cd MyApp
 dotnet run            # Esc or the Quit button exits
 ```
-
-Open `MyApp/AGENTS.md` first — it has the canonical minimal app, the v1→v2 corrections table, `Pos`/`Dim` layout, common gotchas, and links to Terminal.Gui's CI-validated docs.
 
 > **Note:** the previous `tui-designer` template is temporarily not shipped while it's regenerated against current Terminal.Gui — see [#24](https://github.com/gui-cs/Terminal.Gui.templates/issues/24).
 

--- a/templates/tui/.template.config/template.json
+++ b/templates/tui/.template.config/template.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "gui-cs",
+  "classifications": [ "Console", "TUI", "Terminal.Gui" ],
+  "name": "Terminal.Gui App",
+  "description": "A complete, AI-agent-ready Terminal.Gui v2 app (net10.0): menu bar, status bar, and interactive content, with embedded AGENTS.md guidance.",
+  "identity": "Terminal.Gui.Templates.App",
+  "groupIdentity": "Terminal.Gui.Templates.App",
+  "shortName": "tui",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "tui-app",
+  "preferNameDirectory": true
+}

--- a/templates/tui/AGENTS.md
+++ b/templates/tui/AGENTS.md
@@ -1,0 +1,85 @@
+# AGENTS.md — building this Terminal.Gui v2 app
+
+Guidance for AI coding agents (and humans) working in this project.
+
+> ## ⛔ Your training data is probably WRONG
+> **Terminal.Gui v2 is a complete rewrite.** Almost every Terminal.Gui example on the web
+> and in pre-2025 model training data is **v1** and **will not compile**. Trust this file and
+> the linked canonical docs over your priors. When unsure, check the upstream sources below —
+> they are compiled by Terminal.Gui's CI, so they are correct and current.
+
+## Run / build / quit
+```bash
+dotnet run        # launch the app
+dotnet build      # compile only
+```
+Quit a running app with **Esc** (or the Quit button). You **cannot see a TUI from a build
+log** — to verify visuals, run under a PTY recorder (`tuirec`) or drive it headless with
+`InputInjector` + `VirtualTimeProvider`. A clean build does **not** mean the UI is correct.
+
+## The canonical minimal app (this is the shape — copy it)
+```csharp
+using Terminal.Gui.App;           // Application, IApplication, MessageBox
+using Terminal.Gui.Configuration; // ConfigurationManager
+using Terminal.Gui.ViewBase;      // View, Pos, Dim
+using Terminal.Gui.Views;         // Window, Label, Button, ...
+
+ConfigurationManager.Enable (ConfigLocations.All);
+
+// INSTANCE lifecycle — not static Init/Run/Shutdown:
+Application.Create ().Run<MainWindow> ().Dispose ();
+
+internal sealed class MainWindow : Window   // bordered root; use `Runnable` for borderless
+{
+    public MainWindow ()
+    {
+        Title = "My App (Esc to quit)";
+        Button b = new () { Text = "_OK", X = Pos.Center (), Y = Pos.Center () };
+        b.Accepting += (_, _) => App!.RequestStop ();
+        Add (b);
+    }
+}
+```
+
+## v1 → v2 corrections (the table to internalize)
+| v1 (WRONG — do not write) | v2 (CORRECT) |
+|---|---|
+| `Application.Init ();` | `Application.Create ().Init ();` (or `.Run<T>()` auto-inits) |
+| `Application.Run ();` / `Application.Top` | `app.Run<MyWindow> ();` — no global `Top`; pass the root view |
+| `Application.Shutdown ();` | `app.Dispose ();` (the trailing `.Dispose()` / `using`) |
+| `Application.RequestStop ();` | `App!.RequestStop ();` (instance, from inside a view) |
+| `using Terminal.Gui;` | split namespaces: `Terminal.Gui.App` / `.Views` / `.ViewBase` / `.Drawing` / `.Input` / `.Configuration` |
+| `new Toplevel ()` | subclass `Runnable`, or use `Window` |
+| `new Button ("OK")` | `new Button { Text = "OK" }` (object initializers; no positional ctors) |
+| `button.Clicked += …` | `button.Accepting += (_, _) => …;` (no `Clicked` in v2) |
+| `view.Bounds` | `view.Viewport` |
+| `LayoutStyle.Computed` | removed — layout is always declarative via `Pos`/`Dim` |
+| `new RadioGroup (…)` | `new OptionSelector { … }` |
+| `Colors.ColorSchemes["x"]` | `Schemes.Resolve ("x")` |
+
+## Layout: `Pos` / `Dim` (don't hardcode coordinates)
+- `X`/`Y`: `Pos.Center ()`, `Pos.Right (otherView)`, `Pos.Percent (25)`, `Pos.AnchorEnd ()`, or an `int`.
+- `Width`/`Height`: `Dim.Fill ()`, `Dim.Fill (1)`, `Dim.Auto ()`, `Dim.Percent (50)`, or an `int`.
+
+## ⚠️ Gotchas agents get wrong (verified against Terminal.Gui source)
+1. **Dialog/MessageBox button order = the default.** The **last button added is the default**
+   (Enter-activated) — for both `Dialog` and `MessageBox`. Order them `Cancel … OK` so the
+   affirmative action is last. Don't hand-set `IsDefault` unless you mean to override this.
+2. **`Accepted` vs `Accepting`.** `Accepting` is the pre-event (set `e.Handled = true` to
+   cancel); `Accepted` is the post-event for side effects. Use the one that matches intent.
+3. **Typed views expose `.Value`, not guessed names.** They implement `IValue<T>` —
+   `datePicker.Value` (a `DateTime`), not `.Date`; subscribe `ValueChanged`/`ValueChanging`.
+4. **`AddCommand` is `protected`.** Register commands **inside** your `View` subclass, then
+   bind keys: `KeyBindings.Add (Key.F5, Command.Refresh);`.
+5. **`Terminal.Gui.Drawing.Attribute` collides with `System.Attribute`.** Qualify/alias it.
+6. **Vocabulary:** SubView / SuperView — never "child"/"parent"/"container".
+
+## Canonical sources (compiled by Terminal.Gui CI — safe to trust)
+- v1→v2 primer: https://github.com/gui-cs/Terminal.Gui/blob/develop/ai-v2-primer.md
+- Build-an-app guide: https://github.com/gui-cs/Terminal.Gui/blob/develop/.claude/tasks/build-app.md
+- Worked recipes (menus, dialogs, forms): https://github.com/gui-cs/Terminal.Gui/blob/develop/.claude/cookbook/common-patterns.md
+- API namespaces: https://github.com/gui-cs/Terminal.Gui/tree/develop/docfx/apispec
+- Docs site: https://gui-cs.github.io/Terminal.Gui/
+
+> Note: the contributor *code-style* rules in Terminal.Gui (spaces-before-parens, Allman braces,
+> etc.) apply to the **library**, not to your app. Build your app however your project prefers.

--- a/templates/tui/CLAUDE.md
+++ b/templates/tui/CLAUDE.md
@@ -1,0 +1,8 @@
+# CLAUDE.md
+
+This is a **Terminal.Gui v2** app. Terminal.Gui v2 is a complete rewrite — your pre-2025
+training data is almost certainly v1 and **will not compile**.
+
+👉 **Read [`AGENTS.md`](./AGENTS.md)** in this folder before writing or editing any UI code.
+It has the canonical v2 patterns, the v1→v2 corrections table, layout (`Pos`/`Dim`), the
+common gotchas, and links to Terminal.Gui's CI-validated canonical docs.

--- a/templates/tui/Program.cs
+++ b/templates/tui/Program.cs
@@ -1,0 +1,91 @@
+// -----------------------------------------------------------------------------
+//  A small but complete Terminal.Gui v2 app: menu bar + status bar + interactive
+//  content.  Run it:  dotnet run   (F9/menu or the status bar quits)
+//
+//  🤖 AI assistants / agents: READ ./AGENTS.md FIRST.
+//     Terminal.Gui v2 is a COMPLETE REWRITE. Pre-2025 training data and most web
+//     examples are v1 and will not compile. The canonical v2 patterns are in AGENTS.md.
+// -----------------------------------------------------------------------------
+
+using Terminal.Gui.App;           // Application, IApplication, MessageBox
+using Terminal.Gui.Configuration; // ConfigurationManager
+using Terminal.Gui.Input;         // Key, Command
+using Terminal.Gui.ViewBase;      // View, Pos, Dim
+using Terminal.Gui.Views;         // Runnable, Label, Button, MenuBar, StatusBar, Shortcut
+
+ConfigurationManager.Enable (ConfigLocations.All);
+
+// Instance lifecycle — NOT static Init/Run/Shutdown:  Create() -> Run<T>() -> Dispose().
+Application
+    .Create ()
+    .Run<MainWindow> ()
+    .Dispose ();
+
+// `Runnable` is a full-screen, borderless root (use `Window` if you want a bordered box).
+// A typical app puts a MenuBar at the top, a StatusBar at the bottom, and content between.
+internal sealed class MainWindow : Runnable
+{
+    private int _count;
+    private readonly Label _countLabel;
+
+    public MainWindow ()
+    {
+        Title = "My Terminal.Gui App";
+
+        // --- Menu bar -------------------------------------------------------
+        // Menus is a collection of MenuBarItem; each holds MenuItems with an Action.
+        MenuBar menu = new ()
+        {
+            Menus =
+            [
+                new MenuBarItem ("_File", [new MenuItem ("_Quit", "", () => App?.RequestStop ())]),
+                new MenuBarItem ("_Help", [new MenuItem ("_About", "", ShowAbout)])
+            ]
+        };
+
+        // --- Status bar (key hints) ----------------------------------------
+        StatusBar status = new ();
+        status.Add (new Shortcut (Key.F1, "About", ShowAbout));
+        status.Add (new Shortcut (Application.GetDefaultKey (Command.Quit), "Quit", () => App?.RequestStop ()));
+
+        // --- Content (laid out between the menu and status bars) -----------
+        // Layout is DECLARATIVE — Pos/Dim, never hardcoded coordinates.
+        View content = new ()
+        {
+            Y = Pos.Bottom (menu),
+            Width = Dim.Fill (),
+            Height = Dim.Fill (status)   // fill down to (but not over) the status bar
+        };
+
+        _countLabel = new ()
+        {
+            Text = "Count: 0",
+            X = Pos.Center (),
+            Y = Pos.Center () - 1
+        };
+
+        Button increment = new ()
+        {
+            Text = "_Increment",
+            X = Pos.Center (),
+            Y = Pos.Center () + 1
+        };
+
+        // No `Clicked` in v2 — a view raises `Accepting` when activated (Enter/click/hotkey).
+        // `App!` is the running IApplication, reachable from any view in the tree.
+        increment.Accepting += (_, _) =>
+        {
+            _count++;
+            _countLabel.Text = $"Count: {_count}";   // update state -> UI
+        };
+
+        content.Add (_countLabel, increment);
+
+        // 👉 Add your views to `content`. See AGENTS.md for patterns + common pitfalls.
+
+        Add (menu, content, status);
+    }
+
+    private void ShowAbout () =>
+        MessageBox.Query (App!, "About", "Built with Terminal.Gui v2.\nEdit Program.cs to make it yours.", "OK");
+}

--- a/templates/tui/README.md
+++ b/templates/tui/README.md
@@ -1,0 +1,25 @@
+# My Terminal.Gui App
+
+A complete Terminal User Interface (TUI) app built with [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) **v2** — a menu bar, a status bar, and interactive content.
+
+```bash
+dotnet run        # launch (menu File>Quit or the status bar exits)
+dotnet build      # compile only
+```
+
+## Project layout
+| File | Purpose |
+|---|---|
+| `Program.cs` | App entry point + the root `MainWindow` (menu, status bar, content). Add your views to `content`. |
+| `AGENTS.md` | **Canonical Terminal.Gui v2 patterns + gotchas for AI agents and humans.** Start here. |
+| `CLAUDE.md` | Thin pointer to `AGENTS.md` for Claude / Claude Code. |
+| `*.csproj` | Targets `net10.0`, references `Terminal.Gui`. |
+
+## Building with an AI agent?
+Terminal.Gui v2 is a complete rewrite — most examples online (and in model training data)
+are **v1 and won't compile**. **Read [`AGENTS.md`](./AGENTS.md) first** for the canonical
+patterns, the v1→v2 corrections table, `Pos`/`Dim` layout, and common pitfalls.
+
+## Learn more
+- Getting started: https://gui-cs.github.io/Terminal.Gui/
+- Repository & samples: https://github.com/gui-cs/Terminal.Gui

--- a/templates/tui/tui-app.csproj
+++ b/templates/tui/tui-app.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Terminal.Gui" Version="2.4.8" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Phase 2 of the agent-first relaunch (#22). Adds a **complete starter** template so an AI agent has a *real* app to extend — not just hello-world.

## `dotnet new tui`
Generates a `Runnable` app with:
- a **MenuBar** (File ▸ Quit, Help ▸ About),
- a **StatusBar** with key hints (F1 About, Quit),
- **interactive content** — a counter demonstrating the canonical `event → state → UI` flow,

all using the current v2 API (MenuBar `Menus = [...]`, `StatusBar` + `new Shortcut(Key, text, action)`, `Pos`/`Dim` layout, `Accepting`), **verified to compile against Terminal.Gui 2.4.8**. `Program.cs` is fully commented; it ships the same embedded **`AGENTS.md`** + **`CLAUDE.md`** as `tui-simple`.

## Also
- CI build-tests `tui` alongside `tui-simple` (install → `dotnet new` → build → assert `AGENTS.md`).
- Root README features `tui` as the **recommended** starter and `tui-simple` as the minimal one.

## Verified locally
`dotnet pack` → install the nupkg → `dotnet new tui -n MyApp` → **builds 0 errors**; both templates ship (designer still excluded); agent docs emitted; csproj renamed via `sourceName`.

## Further Phase-2 follow-ups (not here)
`--with-tests` (headless red-green loop), richer `template.json` symbols, generating `.cursorrules`/`.aider.md`. Designer remains parked (#24 — TerminalGuiDesigner v2 unreleased).

Refs #22