### PR TITLE
Rename internal references: gui-cs → tui-cs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Terminal.Gui Templates
 
-`dotnet new` templates for building [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) **v2** apps — designed so an **AI coding agent** can scaffold and extend a TUI app correctly. Every generated project ships an **`AGENTS.md`** with the canonical v2 patterns (Terminal.Gui v2 is a complete rewrite, so most online/training-data examples are v1 and won't compile).
+`dotnet new` templates for building [Terminal.Gui](https://github.com/tui-cs/Terminal.Gui) **v2** apps — designed so an **AI coding agent** can scaffold and extend a TUI app correctly. Every generated project ships an **`AGENTS.md`** with the canonical v2 patterns (Terminal.Gui v2 is a complete rewrite, so most online/training-data examples are v1 and won't compile).
 
 ## Install
 
@@ -38,9 +38,9 @@ cd MyApp
 dotnet run            # Esc or the Quit button exits
 ```
 
-> **Note:** the previous `tui-designer` template is temporarily not shipped while it's regenerated against current Terminal.Gui — see [#24](https://github.com/gui-cs/Terminal.Gui.templates/issues/24).
+> **Note:** the previous `tui-designer` template is temporarily not shipped while it's regenerated against current Terminal.Gui — see [#24](https://github.com/tui-cs/Terminal.Gui.templates/issues/24).
 
 ## Links
-- Terminal.Gui: https://github.com/gui-cs/Terminal.Gui
-- Getting started: https://gui-cs.github.io/Terminal.Gui/
-- Relaunch plan: [#22](https://github.com/gui-cs/Terminal.Gui.templates/issues/22)
+- Terminal.Gui: https://github.com/tui-cs/Terminal.Gui
+- Getting started: https://tui-cs.github.io/Terminal.Gui/
+- Relaunch plan: [#22](https://github.com/tui-cs/Terminal.Gui.templates/issues/22)

--- a/TERMINAL_GUI_INTEGRATION.md
+++ b/TERMINAL_GUI_INTEGRATION.md
@@ -18,7 +18,7 @@ Add this step at the end of the `publish` job in `.github/workflows/publish.yml`
       -H "Accept: application/vnd.github+json" \
       -H "Authorization: Bearer ${{ secrets.TEMPLATE_REPO_TOKEN }}" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
-      https://api.github.com/repos/gui-cs/Terminal.Gui.templates/dispatches \
+      https://api.github.com/repos/tui-cs/Terminal.Gui.templates/dispatches \
       -d '{"event_type":"terminal-gui-v2-released","client_payload":{"version":"${{ steps.gitversion.outputs.SemVer }}"}}'
 ```
 
@@ -32,7 +32,7 @@ Alternatively, use the official action:
   uses: peter-evans/repository-dispatch@v3
   with:
     token: ${{ secrets.TEMPLATE_REPO_TOKEN }}
-    repository: gui-cs/Terminal.Gui.templates
+    repository: tui-cs/Terminal.Gui.templates
     event-type: terminal-gui-v2-released
     client-payload: '{"version": "${{ steps.gitversion.outputs.SemVer }}"}'
 ```
@@ -40,7 +40,7 @@ Alternatively, use the official action:
 ## Required Secret
 
 Create a Personal Access Token (PAT) or use a GitHub App token with the following permissions:
-- Repository: `gui-cs/Terminal.Gui.templates`
+- Repository: `tui-cs/Terminal.Gui.templates`
 - Permission: `contents: write` or `repository_dispatch`
 
 Add this token as a secret named `TEMPLATE_REPO_TOKEN` in the Terminal.Gui repository settings.

--- a/Terminal.Gui.templates.csproj
+++ b/Terminal.Gui.templates.csproj
@@ -5,11 +5,11 @@
 		<PackageVersion>2.4.8</PackageVersion>
 		<PackageId>Terminal.Gui.Templates</PackageId>
 		<Title>Terminal.Gui templates</Title>
-		<Authors>gui-cs</Authors>
+		<Authors>tui-cs</Authors>
 		<Description>AI-agent-ready `dotnet new` templates for building Terminal.Gui v2 apps (net10.0). Generated projects ship embedded AGENTS.md guidance with the canonical v2 patterns.</Description>
 		<PackageTags>dotnet-new;templates;template;terminal;tui;gui;console;csharp;terminal.gui;ai-agents</PackageTags>
 		<TargetFramework>net10.0</TargetFramework>
-		<PackageProjectUrl>https://github.com/gui-cs/Terminal.Gui.templates</PackageProjectUrl>
+		<PackageProjectUrl>https://github.com/tui-cs/Terminal.Gui.templates</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<IncludeContentInPack>true</IncludeContentInPack>

--- a/templates/tui-designer/README.md
+++ b/templates/tui-designer/README.md
@@ -1,6 +1,6 @@
 # Terminal.Gui Designer Template
 
-A starter template for building Terminal User Interface (TUI) applications with [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) v2, designed to work with the [Terminal.Gui Designer](https://github.com/gui-cs/TerminalGuiDesigner).
+A starter template for building Terminal User Interface (TUI) applications with [Terminal.Gui](https://github.com/tui-cs/Terminal.Gui) v2, designed to work with the [Terminal.Gui Designer](https://github.com/tui-cs/TerminalGuiDesigner).
 
 ## Usage
 
@@ -26,7 +26,7 @@ dotnet run
 
 ## Terminal.Gui Designer
 
-This template is optimized for use with [Terminal.Gui Designer](https://github.com/gui-cs/TerminalGuiDesigner), a visual designer for creating Terminal.Gui interfaces.
+This template is optimized for use with [Terminal.Gui Designer](https://github.com/tui-cs/TerminalGuiDesigner), a visual designer for creating Terminal.Gui interfaces.
 
 Install the designer:
 
@@ -36,6 +36,6 @@ dotnet tool install --global TerminalGuiDesigner
 
 ## Learn More
 
-- [Terminal.Gui Documentation](https://gui-cs.github.io/Terminal.GuiV2Docs/)
-- [Terminal.Gui GitHub](https://github.com/gui-cs/Terminal.Gui)
-- [Terminal.Gui Designer](https://github.com/gui-cs/TerminalGuiDesigner)
+- [Terminal.Gui Documentation](https://tui-cs.github.io/Terminal.GuiV2Docs/)
+- [Terminal.Gui GitHub](https://github.com/tui-cs/Terminal.Gui)
+- [Terminal.Gui Designer](https://github.com/tui-cs/TerminalGuiDesigner)

--- a/templates/tui-simple/.template.config/template.json
+++ b/templates/tui-simple/.template.config/template.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/template",
-  "author": "gui-cs",
+  "author": "tui-cs",
   "classifications": [ "Console", "TUI", "Terminal.Gui" ],
   "name": "Terminal.Gui Simple App",
   "description": "A minimal, AI-agent-ready Terminal.Gui v2 app (net10.0) with embedded AGENTS.md guidance.",

--- a/templates/tui-simple/AGENTS.md
+++ b/templates/tui-simple/AGENTS.md
@@ -75,11 +75,11 @@ internal sealed class MainWindow : Window   // bordered root; use `Runnable` for
 6. **Vocabulary:** SubView / SuperView — never "child"/"parent"/"container".
 
 ## Canonical sources (compiled by Terminal.Gui CI — safe to trust)
-- v1→v2 primer: https://github.com/gui-cs/Terminal.Gui/blob/develop/ai-v2-primer.md
-- Build-an-app guide: https://github.com/gui-cs/Terminal.Gui/blob/develop/.claude/tasks/build-app.md
-- Worked recipes (menus, dialogs, forms): https://github.com/gui-cs/Terminal.Gui/blob/develop/.claude/cookbook/common-patterns.md
-- API namespaces: https://github.com/gui-cs/Terminal.Gui/tree/develop/docfx/apispec
-- Docs site: https://gui-cs.github.io/Terminal.Gui/
+- v1→v2 primer: https://github.com/tui-cs/Terminal.Gui/blob/develop/ai-v2-primer.md
+- Build-an-app guide: https://github.com/tui-cs/Terminal.Gui/blob/develop/.claude/tasks/build-app.md
+- Worked recipes (menus, dialogs, forms): https://github.com/tui-cs/Terminal.Gui/blob/develop/.claude/cookbook/common-patterns.md
+- API namespaces: https://github.com/tui-cs/Terminal.Gui/tree/develop/docfx/apispec
+- Docs site: https://tui-cs.github.io/Terminal.Gui/
 
 > Note: the contributor *code-style* rules in Terminal.Gui (spaces-before-parens, Allman braces,
 > etc.) apply to the **library**, not to your app. Build your app however your project prefers.

--- a/templates/tui-simple/README.md
+++ b/templates/tui-simple/README.md
@@ -1,6 +1,6 @@
 # My Terminal.Gui App
 
-A minimal Terminal User Interface (TUI) app built with [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) **v2**.
+A minimal Terminal User Interface (TUI) app built with [Terminal.Gui](https://github.com/tui-cs/Terminal.Gui) **v2**.
 
 ```bash
 dotnet run        # launch (Esc or the Quit button exits)
@@ -22,6 +22,6 @@ minimal app, the v1→v2 corrections table, `Pos`/`Dim` layout, the common pitfa
 to Terminal.Gui's CI-validated docs.
 
 ## Learn more
-- Getting started: https://gui-cs.github.io/Terminal.Gui/
-- Repository & samples: https://github.com/gui-cs/Terminal.Gui
-- v1→v2 primer: https://github.com/gui-cs/Terminal.Gui/blob/develop/ai-v2-primer.md
+- Getting started: https://tui-cs.github.io/Terminal.Gui/
+- Repository & samples: https://github.com/tui-cs/Terminal.Gui
+- v1→v2 primer: https://github.com/tui-cs/Terminal.Gui/blob/develop/ai-v2-primer.md

--- a/templates/tui/.template.config/template.json
+++ b/templates/tui/.template.config/template.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/template",
-  "author": "gui-cs",
+  "author": "tui-cs",
   "classifications": [ "Console", "TUI", "Terminal.Gui" ],
   "name": "Terminal.Gui App",
   "description": "A complete, AI-agent-ready Terminal.Gui v2 app (net10.0): menu bar, status bar, and interactive content, with embedded AGENTS.md guidance.",

--- a/templates/tui/AGENTS.md
+++ b/templates/tui/AGENTS.md
@@ -75,11 +75,11 @@ internal sealed class MainWindow : Window   // bordered root; use `Runnable` for
 6. **Vocabulary:** SubView / SuperView — never "child"/"parent"/"container".
 
 ## Canonical sources (compiled by Terminal.Gui CI — safe to trust)
-- v1→v2 primer: https://github.com/gui-cs/Terminal.Gui/blob/develop/ai-v2-primer.md
-- Build-an-app guide: https://github.com/gui-cs/Terminal.Gui/blob/develop/.claude/tasks/build-app.md
-- Worked recipes (menus, dialogs, forms): https://github.com/gui-cs/Terminal.Gui/blob/develop/.claude/cookbook/common-patterns.md
-- API namespaces: https://github.com/gui-cs/Terminal.Gui/tree/develop/docfx/apispec
-- Docs site: https://gui-cs.github.io/Terminal.Gui/
+- v1→v2 primer: https://github.com/tui-cs/Terminal.Gui/blob/develop/ai-v2-primer.md
+- Build-an-app guide: https://github.com/tui-cs/Terminal.Gui/blob/develop/.claude/tasks/build-app.md
+- Worked recipes (menus, dialogs, forms): https://github.com/tui-cs/Terminal.Gui/blob/develop/.claude/cookbook/common-patterns.md
+- API namespaces: https://github.com/tui-cs/Terminal.Gui/tree/develop/docfx/apispec
+- Docs site: https://tui-cs.github.io/Terminal.Gui/
 
 > Note: the contributor *code-style* rules in Terminal.Gui (spaces-before-parens, Allman braces,
 > etc.) apply to the **library**, not to your app. Build your app however your project prefers.

--- a/templates/tui/README.md
+++ b/templates/tui/README.md
@@ -1,6 +1,6 @@
 # My Terminal.Gui App
 
-A complete Terminal User Interface (TUI) app built with [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) **v2** — a menu bar, a status bar, and interactive content.
+A complete Terminal User Interface (TUI) app built with [Terminal.Gui](https://github.com/tui-cs/Terminal.Gui) **v2** — a menu bar, a status bar, and interactive content.
 
 ```bash
 dotnet run        # launch (menu File>Quit or the status bar exits)
@@ -21,5 +21,5 @@ are **v1 and won't compile**. **Read [`AGENTS.md`](./AGENTS.md) first** for the 
 patterns, the v1→v2 corrections table, `Pos`/`Dim` layout, and common pitfalls.
 
 ## Learn more
-- Getting started: https://gui-cs.github.io/Terminal.Gui/
-- Repository & samples: https://github.com/gui-cs/Terminal.Gui
+- Getting started: https://tui-cs.github.io/Terminal.Gui/
+- Repository & samples: https://github.com/tui-cs/Terminal.Gui


### PR DESCRIPTION
Closes #31.

Part of the org-wide rename **gui-cs → tui-cs**. GitHub auto-redirects all `github.com/gui-cs/*` URLs; this updates *internal* references for self-consistency.

## What changed
10 files. Rule: every **`gui-cs`** (hyphen — org login) → **`tui-cs`**. Historical brand **`gui.cs`** (dot) left as-is. Machine-local absolute paths left untouched.

Notable functional references (verify after rename, since auto-redirect covers the gap):
- **`TERMINAL_GUI_INTEGRATION.md`** — `repository_dispatch` target `gui-cs/Terminal.Gui.templates` (received from Terminal.Gui's publish.yml).
- **`Terminal.Gui.templates.csproj`** — `<Authors>` and `<PackageProjectUrl>` (NuGet package metadata).
- **`.template.config/template.json`** (tui, tui-simple) — `author` field shown to `dotnet new` users.
- Template content README/AGENTS.md URLs (`gui-cs.github.io` docs + GitHub repo links) — these are the URLs new users receive.

## ⚠️ DRAFT until after the rename
Prep-first. Do not merge before the org rename.