### PR TITLE
Phase 2: add --WithTests to the flagship 'tui' template (headless red-green loop)

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -63,9 +63,9 @@ jobs:
         run: |
           v='${{ steps.get_version.outputs.latest_version }}'
           sed -i "s|\(<PackageVersion>\)[^<]*\(</PackageVersion>\)|\1$v\2|" Terminal.Gui.templates.csproj
-          # Bump the Terminal.Gui reference in EVERY template csproj (so new templates are
-          # covered automatically — no per-template edits needed here).
-          for proj in templates/*/*.csproj; do
+          # Bump the Terminal.Gui reference in EVERY template csproj, recursively (covers new
+          # templates and nested test projects automatically — no per-template edits needed).
+          find templates -name '*.csproj' -print0 | while IFS= read -r -d '' proj; do
             sed -i "s|\(<PackageReference Include=\"Terminal.Gui\" Version=\"\)[^\"]*\(\".*\)|\1$v\2|" "$proj"
           done
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,9 @@ jobs:
         run: |
           v='${{ steps.get_version.outputs.latest_version }}'
           sed -i "s|\(<PackageVersion>\)[^<]*\(</PackageVersion>\)|\1$v\2|" Terminal.Gui.templates.csproj
-          # Bump the Terminal.Gui reference in EVERY template csproj (so new templates are
-          # covered automatically — no per-template edits needed here).
-          for proj in templates/*/*.csproj; do
+          # Bump the Terminal.Gui reference in EVERY template csproj, recursively (covers new
+          # templates and nested test projects automatically — no per-template edits needed).
+          find templates -name '*.csproj' -print0 | while IFS= read -r -d '' proj; do
             sed -i "s|\(<PackageReference Include=\"Terminal.Gui\" Version=\"\)[^\"]*\(\".*\)|\1$v\2|" "$proj"
           done
 
@@ -72,3 +72,10 @@ jobs:
             dotnet build "/tmp/$t-test"
             echo "::endgroup::"
           done
+          # The flagship's --WithTests path must scaffold a test project whose example tests pass.
+          echo "::group::tui --WithTests"
+          rm -rf /tmp/with-tests
+          dotnet new tui -n WithTestsApp --WithTests -o /tmp/with-tests
+          test -d /tmp/with-tests/Tests || { echo "::error::--WithTests did not emit Tests/"; exit 1; }
+          dotnet test /tmp/with-tests/Tests
+          echo "::endgroup::"

--- a/templates/tui/.template.config/template.json
+++ b/templates/tui/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "gui-cs",
   "classifications": [ "Console", "TUI", "Terminal.Gui" ],
   "name": "Terminal.Gui App",
-  "description": "A complete, AI-agent-ready Terminal.Gui v2 app (net10.0): menu bar, status bar, and interactive content, with embedded AGENTS.md guidance.",
+  "description": "A complete, AI-agent-ready Terminal.Gui v2 app (net10.0): menu bar, status bar, and interactive content, with embedded AGENTS.md guidance. Optionally scaffolds a headless xUnit test project.",
   "identity": "Terminal.Gui.Templates.App",
   "groupIdentity": "Terminal.Gui.Templates.App",
   "shortName": "tui",
@@ -12,5 +12,23 @@
     "type": "project"
   },
   "sourceName": "tui-app",
-  "preferNameDirectory": true
+  "preferNameDirectory": true,
+  "symbols": {
+    "WithTests": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Also scaffold an xUnit test project with headless example tests (a red-green loop for agents)."
+    }
+  },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(!WithTests)",
+          "exclude": [ "Tests/**" ]
+        }
+      ]
+    }
+  ]
 }

--- a/templates/tui/Program.cs
+++ b/templates/tui/Program.cs
@@ -23,7 +23,10 @@ Application
 
 // `Runnable` is a full-screen, borderless root (use `Window` if you want a bordered box).
 // A typical app puts a MenuBar at the top, a StatusBar at the bottom, and content between.
-internal sealed class MainWindow : Runnable
+//
+// `public` so the optional test project can construct it (scaffold it with `--WithTests`).
+// Terminal.Gui views can be built and exercised headlessly — no terminal needed for logic tests.
+public sealed class MainWindow : Runnable
 {
     private int _count;
     private readonly Label _countLabel;

--- a/templates/tui/README.md
+++ b/templates/tui/README.md
@@ -7,6 +7,9 @@ dotnet run        # launch (menu File>Quit or the status bar exits)
 dotnet build      # compile only
 ```
 
+Generate with `dotnet new tui --WithTests` to also scaffold a `Tests/` project with **headless**
+example tests (`dotnet test Tests`) — a fast red-green loop you can run without a terminal.
+
 ## Project layout
 | File | Purpose |
 |---|---|

--- a/templates/tui/Tests/MainWindowTests.cs
+++ b/templates/tui/Tests/MainWindowTests.cs
@@ -1,0 +1,64 @@
+// Headless tests for the app's views — no real terminal, no Application.Init.
+//
+// Terminal.Gui v2 views can be constructed and exercised in-process: build the view,
+// trigger a command (e.g. Command.Accept), and assert on the resulting state. This is the
+// fast red-green loop for an AI agent — you do NOT need a PTY to test view *logic*.
+// (To verify *visuals*, run the app under a PTY recorder; see AGENTS.md.)
+
+using Terminal.Gui.Input;     // Command
+using Terminal.Gui.ViewBase;  // View
+using Terminal.Gui.Views;     // Label, Button
+using Xunit;
+
+public class MainWindowTests
+{
+    [Fact]
+    public void Constructs_with_the_expected_title ()
+    {
+        using MainWindow window = new ();
+        Assert.Equal ("My Terminal.Gui App", window.Title);
+    }
+
+    [Fact]
+    public void Increment_button_increments_the_count ()
+    {
+        using MainWindow window = new ();
+
+        Label count = FindFirst<Label> (window, l => l.Text.StartsWith ("Count:"));
+        Button increment = FindFirst<Button> (window, b => b.Text.Contains ("Increment"));
+
+        Assert.Equal ("Count: 0", count.Text);
+
+        // Activate the button as if the user pressed it (Enter/click/hotkey all map to Accept).
+        increment.InvokeCommand (Command.Accept);
+
+        Assert.Equal ("Count: 1", count.Text);
+    }
+
+    // Walk the view tree (SubView/SuperView) to find a view matching a predicate.
+    private static T FindFirst<T> (View root, System.Func<T, bool> match) where T : View
+    {
+        foreach (View view in Descendants (root))
+        {
+            if (view is T typed && match (typed))
+            {
+                return typed;
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException ($"No {typeof (T).Name} matched the predicate.");
+    }
+
+    private static System.Collections.Generic.IEnumerable<View> Descendants (View view)
+    {
+        foreach (View child in view.SubViews)
+        {
+            yield return child;
+
+            foreach (View descendant in Descendants (child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+}

--- a/templates/tui/Tests/tui-app.Tests.csproj
+++ b/templates/tui/Tests/tui-app.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Terminal.Gui" Version="2.4.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Reference the app so we can construct and exercise its views headlessly. -->
+    <ProjectReference Include="..\tui-app.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/templates/tui/tui-app.csproj
+++ b/templates/tui/tui-app.csproj
@@ -12,4 +12,11 @@
     <PackageReference Include="Terminal.Gui" Version="2.4.8" />
   </ItemGroup>
 
+  <!-- The optional test project (the WithTests option) lives under Tests/ in this folder;
+       keep its sources out of the app's own compilation. Harmless when Tests/ isn't generated. -->
+  <ItemGroup>
+    <Compile Remove="Tests\**" />
+    <None Remove="Tests\**" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Phase 2 (#28) of the agent-first relaunch (#22). Adds an opt-in test project so agents get a fast **red-green loop**.

## `dotnet new tui --WithTests`
Also scaffolds a `Tests/` xUnit project that exercises the app's views **headlessly** — no terminal, no `Application.Init`:

```csharp
using MainWindow window = new ();
Button increment = FindFirst<Button> (window, b => b.Text.Contains ("Increment"));
increment.InvokeCommand (Command.Accept);   // activate as if the user pressed it
Assert.Equal ("Count: 1", count.Text);
```

This is TG's recommended approach (construct views, trigger commands, assert state — no PTY needed for *logic* tests).

## How it's wired
- `template.json` `WithTests` bool symbol + a `sources` modifier that **excludes `Tests/**` unless requested**.
- `MainWindow` made `public` so the test can construct it; `Tests/**` excluded from the app's own compilation so the flat layout builds either way.
- CI now build-tests the `--WithTests` path and runs `dotnet test`.
- Version auto-bump switched to a **recursive** `find templates -name '*.csproj'` so the nested test project's `Terminal.Gui` reference also advances on release.

## Verified
`dotnet pack` → install nupkg → `dotnet new tui --WithTests` → `dotnet test` = **2 passed**. The default (no `--WithTests`) path is unchanged: no `Tests/`, app builds clean.

> Note: the CLI flag is `--WithTests` (the template engine derives it PascalCase from the symbol; this SDK doesn't kebab-case it).

Refs #22, #28