### PR TITLE
Phase 2: add global.json + .editorconfig to generated output

### DIFF
--- a/Terminal.Gui.templates.csproj
+++ b/Terminal.Gui.templates.csproj
@@ -16,6 +16,9 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
 		<ContentTargetFolders>content</ContentTargetFolders>
+		<!-- Template output includes dotfiles (.editorconfig, .template.config); without this,
+		     NuGet silently drops files starting with '.' from the package (NU5119). -->
+		<NoDefaultExcludes>true</NoDefaultExcludes>
 		<PackageReleaseNotes>
 			2.4.x
 			- Relaunch as the AI-agent-first on-ramp to Terminal.Gui v2.

--- a/templates/tui-simple/.editorconfig
+++ b/templates/tui-simple/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.cs]
+indent_size = 4
+
+[*.{csproj,props,json,yml,yaml,md}]
+indent_size = 2

--- a/templates/tui-simple/global.json
+++ b/templates/tui-simple/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestMajor"
+  }
+}

--- a/templates/tui/.editorconfig
+++ b/templates/tui/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.cs]
+indent_size = 4
+
+[*.{csproj,props,json,yml,yaml,md}]
+indent_size = 2

--- a/templates/tui/global.json
+++ b/templates/tui/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestMajor"
+  }
+}


### PR DESCRIPTION
Phase 2 (#28) of the agent-first relaunch (#22). Stabilizes the generated project's environment for agents.

## Added to every generated project (`tui` + `tui-simple`)
- **`global.json`** — pins the SDK to .NET 10 (`rollForward: latestMajor`) so an agent's `dotnet` commands are deterministic. It's never more restrictive than the `net10.0` TFM already requires.
- **`.editorconfig`** — minimal, **neutral** editor settings (charset / indent / final-newline / trim trailing) so agent + human edits stay consistent. Deliberately **not** Terminal.Gui's contributor style (app authors format however they like).

## Packaging
NuGet drops dotfiles from packages by default (NU5119 silently excluded `.editorconfig`), so this sets `<NoDefaultExcludes>true</NoDefaultExcludes>` on the package. Verified `bin/`/`obj/` stay excluded and no junk dotfiles slip in.

## Verified from the packed nupkg
Install → `dotnet new tui` → both files emitted, app builds; `tui --WithTests` still passes.

## Note — closes out #28
The remaining `Framework` choice symbol is **moot**: Terminal.Gui is **net10.0-only**, so there are no valid alternatives to offer. With the flagship `tui` (#25), `--WithTests` (#33), and this, #28 is effectively complete.

Refs #22, #28