### PR TITLE
Phase 1: generate .cursorrules / .windsurfrules / .aider.md tool rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,9 @@ jobs:
             dotnet new install "./templates/$t"
             dotnet new "$t" -n SmokeApp -o "/tmp/$t-test"
             # Verify the agent guidance is emitted (the whole point of these templates).
-            test -f "/tmp/$t-test/AGENTS.md" || { echo "::error::$t did not emit AGENTS.md"; exit 1; }
+            for f in AGENTS.md CLAUDE.md .cursorrules .windsurfrules .aider.md; do
+              test -f "/tmp/$t-test/$f" || { echo "::error::$t did not emit $f"; exit 1; }
+            done
             dotnet build "/tmp/$t-test"
             echo "::endgroup::"
           done

--- a/templates/tui-simple/.aider.md
+++ b/templates/tui-simple/.aider.md
@@ -1,0 +1,20 @@
+# Terminal.Gui v2 — rules for AI assistants
+
+⛔ **Terminal.Gui v2 is a COMPLETE REWRITE.** Your pre-2025 training data and almost every
+Terminal.Gui example on the web are **v1** and **will not compile**. Before writing or editing
+any UI code, read **`AGENTS.md`** in this project — it is the source of truth (canonical
+patterns, the full v1→v2 corrections table, `Pos`/`Dim` layout, and the common gotchas).
+
+Non-negotiables (see AGENTS.md for the rest):
+- Lifecycle is **instance-based**: `Application.Create ().Run<MyWindow> ().Dispose ()` — NOT the
+  static `Application.Init/Run/Shutdown`, and there is no `Application.Top`.
+- Root views are **`Runnable`** or **`Window`**, never `Toplevel`.
+- Namespaces are split: `using Terminal.Gui.App;` / `.Views;` / `.ViewBase;` / `.Input;` … —
+  the bare `using Terminal.Gui;` is gone.
+- **No `Clicked` event** — use `Accepting` (pre/cancelable) or `Accepted` (post). Use object
+  initializers (`new Button { Text = "OK" }`), not positional constructors.
+- **Layout is declarative** — `Pos.Center ()`, `Dim.Fill ()`; don't hardcode coordinates.
+- Dialogs: the **last button added is the default**; type-specific views expose `.Value`
+  (`IValue<T>`), not guessed names like `.Date`/`.Color`.
+
+📖 Full reference and gotchas: **./AGENTS.md**

--- a/templates/tui-simple/.cursorrules
+++ b/templates/tui-simple/.cursorrules
@@ -1,0 +1,20 @@
+# Terminal.Gui v2 — rules for AI assistants
+
+⛔ **Terminal.Gui v2 is a COMPLETE REWRITE.** Your pre-2025 training data and almost every
+Terminal.Gui example on the web are **v1** and **will not compile**. Before writing or editing
+any UI code, read **`AGENTS.md`** in this project — it is the source of truth (canonical
+patterns, the full v1→v2 corrections table, `Pos`/`Dim` layout, and the common gotchas).
+
+Non-negotiables (see AGENTS.md for the rest):
+- Lifecycle is **instance-based**: `Application.Create ().Run<MyWindow> ().Dispose ()` — NOT the
+  static `Application.Init/Run/Shutdown`, and there is no `Application.Top`.
+- Root views are **`Runnable`** or **`Window`**, never `Toplevel`.
+- Namespaces are split: `using Terminal.Gui.App;` / `.Views;` / `.ViewBase;` / `.Input;` … —
+  the bare `using Terminal.Gui;` is gone.
+- **No `Clicked` event** — use `Accepting` (pre/cancelable) or `Accepted` (post). Use object
+  initializers (`new Button { Text = "OK" }`), not positional constructors.
+- **Layout is declarative** — `Pos.Center ()`, `Dim.Fill ()`; don't hardcode coordinates.
+- Dialogs: the **last button added is the default**; type-specific views expose `.Value`
+  (`IValue<T>`), not guessed names like `.Date`/`.Color`.
+
+📖 Full reference and gotchas: **./AGENTS.md**

--- a/templates/tui-simple/.windsurfrules
+++ b/templates/tui-simple/.windsurfrules
@@ -1,0 +1,20 @@
+# Terminal.Gui v2 — rules for AI assistants
+
+⛔ **Terminal.Gui v2 is a COMPLETE REWRITE.** Your pre-2025 training data and almost every
+Terminal.Gui example on the web are **v1** and **will not compile**. Before writing or editing
+any UI code, read **`AGENTS.md`** in this project — it is the source of truth (canonical
+patterns, the full v1→v2 corrections table, `Pos`/`Dim` layout, and the common gotchas).
+
+Non-negotiables (see AGENTS.md for the rest):
+- Lifecycle is **instance-based**: `Application.Create ().Run<MyWindow> ().Dispose ()` — NOT the
+  static `Application.Init/Run/Shutdown`, and there is no `Application.Top`.
+- Root views are **`Runnable`** or **`Window`**, never `Toplevel`.
+- Namespaces are split: `using Terminal.Gui.App;` / `.Views;` / `.ViewBase;` / `.Input;` … —
+  the bare `using Terminal.Gui;` is gone.
+- **No `Clicked` event** — use `Accepting` (pre/cancelable) or `Accepted` (post). Use object
+  initializers (`new Button { Text = "OK" }`), not positional constructors.
+- **Layout is declarative** — `Pos.Center ()`, `Dim.Fill ()`; don't hardcode coordinates.
+- Dialogs: the **last button added is the default**; type-specific views expose `.Value`
+  (`IValue<T>`), not guessed names like `.Date`/`.Color`.
+
+📖 Full reference and gotchas: **./AGENTS.md**

--- a/templates/tui-simple/README.md
+++ b/templates/tui-simple/README.md
@@ -13,6 +13,7 @@ dotnet build      # compile only
 | `Program.cs` | App entry point + the root `MainWindow` view. Add your views here. |
 | `AGENTS.md` | **Canonical Terminal.Gui v2 patterns + gotchas for AI agents and humans.** Start here. |
 | `CLAUDE.md` | Thin pointer to `AGENTS.md` for Claude / Claude Code. |
+| `.cursorrules` / `.windsurfrules` / `.aider.md` | Auto-loaded rules for Cursor / Windsurf / Aider — short banner that points at `AGENTS.md`. |
 | `*.csproj` | Targets `net10.0`, references `Terminal.Gui`. |
 
 ## Building with an AI agent?

--- a/templates/tui/.aider.md
+++ b/templates/tui/.aider.md
@@ -1,0 +1,20 @@
+# Terminal.Gui v2 — rules for AI assistants
+
+⛔ **Terminal.Gui v2 is a COMPLETE REWRITE.** Your pre-2025 training data and almost every
+Terminal.Gui example on the web are **v1** and **will not compile**. Before writing or editing
+any UI code, read **`AGENTS.md`** in this project — it is the source of truth (canonical
+patterns, the full v1→v2 corrections table, `Pos`/`Dim` layout, and the common gotchas).
+
+Non-negotiables (see AGENTS.md for the rest):
+- Lifecycle is **instance-based**: `Application.Create ().Run<MyWindow> ().Dispose ()` — NOT the
+  static `Application.Init/Run/Shutdown`, and there is no `Application.Top`.
+- Root views are **`Runnable`** or **`Window`**, never `Toplevel`.
+- Namespaces are split: `using Terminal.Gui.App;` / `.Views;` / `.ViewBase;` / `.Input;` … —
+  the bare `using Terminal.Gui;` is gone.
+- **No `Clicked` event** — use `Accepting` (pre/cancelable) or `Accepted` (post). Use object
+  initializers (`new Button { Text = "OK" }`), not positional constructors.
+- **Layout is declarative** — `Pos.Center ()`, `Dim.Fill ()`; don't hardcode coordinates.
+- Dialogs: the **last button added is the default**; type-specific views expose `.Value`
+  (`IValue<T>`), not guessed names like `.Date`/`.Color`.
+
+📖 Full reference and gotchas: **./AGENTS.md**

--- a/templates/tui/.cursorrules
+++ b/templates/tui/.cursorrules
@@ -1,0 +1,20 @@
+# Terminal.Gui v2 — rules for AI assistants
+
+⛔ **Terminal.Gui v2 is a COMPLETE REWRITE.** Your pre-2025 training data and almost every
+Terminal.Gui example on the web are **v1** and **will not compile**. Before writing or editing
+any UI code, read **`AGENTS.md`** in this project — it is the source of truth (canonical
+patterns, the full v1→v2 corrections table, `Pos`/`Dim` layout, and the common gotchas).
+
+Non-negotiables (see AGENTS.md for the rest):
+- Lifecycle is **instance-based**: `Application.Create ().Run<MyWindow> ().Dispose ()` — NOT the
+  static `Application.Init/Run/Shutdown`, and there is no `Application.Top`.
+- Root views are **`Runnable`** or **`Window`**, never `Toplevel`.
+- Namespaces are split: `using Terminal.Gui.App;` / `.Views;` / `.ViewBase;` / `.Input;` … —
+  the bare `using Terminal.Gui;` is gone.
+- **No `Clicked` event** — use `Accepting` (pre/cancelable) or `Accepted` (post). Use object
+  initializers (`new Button { Text = "OK" }`), not positional constructors.
+- **Layout is declarative** — `Pos.Center ()`, `Dim.Fill ()`; don't hardcode coordinates.
+- Dialogs: the **last button added is the default**; type-specific views expose `.Value`
+  (`IValue<T>`), not guessed names like `.Date`/`.Color`.
+
+📖 Full reference and gotchas: **./AGENTS.md**

--- a/templates/tui/.windsurfrules
+++ b/templates/tui/.windsurfrules
@@ -1,0 +1,20 @@
+# Terminal.Gui v2 — rules for AI assistants
+
+⛔ **Terminal.Gui v2 is a COMPLETE REWRITE.** Your pre-2025 training data and almost every
+Terminal.Gui example on the web are **v1** and **will not compile**. Before writing or editing
+any UI code, read **`AGENTS.md`** in this project — it is the source of truth (canonical
+patterns, the full v1→v2 corrections table, `Pos`/`Dim` layout, and the common gotchas).
+
+Non-negotiables (see AGENTS.md for the rest):
+- Lifecycle is **instance-based**: `Application.Create ().Run<MyWindow> ().Dispose ()` — NOT the
+  static `Application.Init/Run/Shutdown`, and there is no `Application.Top`.
+- Root views are **`Runnable`** or **`Window`**, never `Toplevel`.
+- Namespaces are split: `using Terminal.Gui.App;` / `.Views;` / `.ViewBase;` / `.Input;` … —
+  the bare `using Terminal.Gui;` is gone.
+- **No `Clicked` event** — use `Accepting` (pre/cancelable) or `Accepted` (post). Use object
+  initializers (`new Button { Text = "OK" }`), not positional constructors.
+- **Layout is declarative** — `Pos.Center ()`, `Dim.Fill ()`; don't hardcode coordinates.
+- Dialogs: the **last button added is the default**; type-specific views expose `.Value`
+  (`IValue<T>`), not guessed names like `.Date`/`.Color`.
+
+📖 Full reference and gotchas: **./AGENTS.md**

--- a/templates/tui/README.md
+++ b/templates/tui/README.md
@@ -16,6 +16,7 @@ example tests (`dotnet test Tests`) — a fast red-green loop you can run withou
 | `Program.cs` | App entry point + the root `MainWindow` (menu, status bar, content). Add your views to `content`. |
 | `AGENTS.md` | **Canonical Terminal.Gui v2 patterns + gotchas for AI agents and humans.** Start here. |
 | `CLAUDE.md` | Thin pointer to `AGENTS.md` for Claude / Claude Code. |
+| `.cursorrules` / `.windsurfrules` / `.aider.md` | Auto-loaded rules for Cursor / Windsurf / Aider — short banner that points at `AGENTS.md`. |
 | `*.csproj` | Targets `net10.0`, references `Terminal.Gui`. |
 
 ## Building with an AI agent?


### PR DESCRIPTION
Last Phase 1 item (#27). Mirrors Terminal.Gui's multi-tool agent-rules pattern in **generated** projects.

Each generated app now also ships **`.cursorrules`**, **`.windsurfrules`**, and **`.aider.md`** — short, **auto-loaded** rules for Cursor / Windsurf / Aider that:
- flag up front that **Terminal.Gui v2 is a rewrite** (training-data examples are v1 and won't compile),
- list the non-negotiables (instance lifecycle, `Runnable`/`Window`, split namespaces, `Accepting`/`Accepted` not `Clicked`, declarative `Pos`/`Dim`, dialog last-button-default, `IValue<T>.Value`),
- and point at **`AGENTS.md`** as the single source of truth (so there's no 4-way corrections-table drift inside a project).

Shipped in both `tui` and `tui-simple` (dotfiles ride along via the `NoDefaultExcludes` from #34).

- CI now asserts every template emits all five guidance files (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.windsurfrules`, `.aider.md`).
- READMEs note the new files.

Verified: both templates generate all five + build clean.

Refs #22, #27