### PR TITLE
Align templates to the 'Accepted for side effects' rule

### DIFF
--- a/templates/tui-simple/.aider.md
+++ b/templates/tui-simple/.aider.md
@@ -11,7 +11,7 @@ Non-negotiables (see AGENTS.md for the rest):
 - Root views are **`Runnable`** or **`Window`**, never `Toplevel`.
 - Namespaces are split: `using Terminal.Gui.App;` / `.Views;` / `.ViewBase;` / `.Input;` … —
   the bare `using Terminal.Gui;` is gone.
-- **No `Clicked` event** — use `Accepting` (pre/cancelable) or `Accepted` (post). Use object
+- **No `Clicked` event** — use `Accepted` for side effects; `Accepting` only to cancel (`e.Handled = true`). Use object
   initializers (`new Button { Text = "OK" }`), not positional constructors.
 - **Layout is declarative** — `Pos.Center ()`, `Dim.Fill ()`; don't hardcode coordinates.
 - Dialogs: the **last button added is the default**; type-specific views expose `.Value`

--- a/templates/tui-simple/.cursorrules
+++ b/templates/tui-simple/.cursorrules
@@ -11,7 +11,7 @@ Non-negotiables (see AGENTS.md for the rest):
 - Root views are **`Runnable`** or **`Window`**, never `Toplevel`.
 - Namespaces are split: `using Terminal.Gui.App;` / `.Views;` / `.ViewBase;` / `.Input;` … —
   the bare `using Terminal.Gui;` is gone.
-- **No `Clicked` event** — use `Accepting` (pre/cancelable) or `Accepted` (post). Use object
+- **No `Clicked` event** — use `Accepted` for side effects; `Accepting` only to cancel (`e.Handled = true`). Use object
   initializers (`new Button { Text = "OK" }`), not positional constructors.
 - **Layout is declarative** — `Pos.Center ()`, `Dim.Fill ()`; don't hardcode coordinates.
 - Dialogs: the **last button added is the default**; type-specific views expose `.Value`

--- a/templates/tui-simple/.windsurfrules
+++ b/templates/tui-simple/.windsurfrules
@@ -11,7 +11,7 @@ Non-negotiables (see AGENTS.md for the rest):
 - Root views are **`Runnable`** or **`Window`**, never `Toplevel`.
 - Namespaces are split: `using Terminal.Gui.App;` / `.Views;` / `.ViewBase;` / `.Input;` … —
   the bare `using Terminal.Gui;` is gone.
-- **No `Clicked` event** — use `Accepting` (pre/cancelable) or `Accepted` (post). Use object
+- **No `Clicked` event** — use `Accepted` for side effects; `Accepting` only to cancel (`e.Handled = true`). Use object
   initializers (`new Button { Text = "OK" }`), not positional constructors.
 - **Layout is declarative** — `Pos.Center ()`, `Dim.Fill ()`; don't hardcode coordinates.
 - Dialogs: the **last button added is the default**; type-specific views expose `.Value`

--- a/templates/tui-simple/AGENTS.md
+++ b/templates/tui-simple/AGENTS.md
@@ -35,7 +35,7 @@ internal sealed class MainWindow : Window   // bordered root; use `Runnable` for
     {
         Title = "My App (Esc to quit)";
         Button b = new () { Text = "_OK", X = Pos.Center (), Y = Pos.Center () };
-        b.Accepting += (_, _) => App!.RequestStop ();
+        b.Accepted += (_, _) => App!.RequestStop ();
         Add (b);
     }
 }
@@ -51,7 +51,7 @@ internal sealed class MainWindow : Window   // bordered root; use `Runnable` for
 | `using Terminal.Gui;` | split namespaces: `Terminal.Gui.App` / `.Views` / `.ViewBase` / `.Drawing` / `.Input` / `.Configuration` |
 | `new Toplevel ()` | subclass `Runnable`, or use `Window` |
 | `new Button ("OK")` | `new Button { Text = "OK" }` (object initializers; no positional ctors) |
-| `button.Clicked += …` | `button.Accepting += (_, _) => …;` (no `Clicked` in v2) |
+| `button.Clicked += …` | `button.Accepted += (_, _) => …;` (no `Clicked` in v2) |
 | `view.Bounds` | `view.Viewport` |
 | `LayoutStyle.Computed` | removed — layout is always declarative via `Pos`/`Dim` |
 | `new RadioGroup (…)` | `new OptionSelector { … }` |
@@ -66,7 +66,7 @@ internal sealed class MainWindow : Window   // bordered root; use `Runnable` for
    (Enter-activated) — for both `Dialog` and `MessageBox`. Order them `Cancel … OK` so the
    affirmative action is last. Don't hand-set `IsDefault` unless you mean to override this.
 2. **`Accepted` vs `Accepting`.** `Accepting` is the pre-event (set `e.Handled = true` to
-   cancel); `Accepted` is the post-event for side effects. Use the one that matches intent.
+   cancel); `Accepted` is the post-event for side effects. Default to `Accepted`; reach for `Accepting` only to cancel.
 3. **Typed views expose `.Value`, not guessed names.** They implement `IValue<T>` —
    `datePicker.Value` (a `DateTime`), not `.Date`; subscribe `ValueChanged`/`ValueChanging`.
 4. **`AddCommand` is `protected`.** Register commands **inside** your `View` subclass, then

--- a/templates/tui-simple/Program.cs
+++ b/templates/tui-simple/Program.cs
@@ -49,11 +49,11 @@ internal sealed class MainWindow : Window
             Y = Pos.Center ()
         };
 
-        // v2 has NO `Clicked` event. A view raises `Accepting` when the user activates it
-        // (Enter / click / hotkey); set e.Handled = true to cancel. `Accepted` is the
-        // post-activation variant — see AGENTS.md (#Events) for which to use when.
+        // v2 has NO `Clicked` event. Use `Accepted` for side effects like this — it fires when
+        // the user activates the view (Enter / click / hotkey). Use `Accepting` only to inspect
+        // or cancel the activation (set e.Handled = true). See AGENTS.md (#Events).
         // `App!` is the running IApplication, reachable from any view in the tree.
-        quit.Accepting += (_, _) => App!.RequestStop ();
+        quit.Accepted += (_, _) => App!.RequestStop ();
 
         Add (welcome, quit);
 

--- a/templates/tui/.aider.md
+++ b/templates/tui/.aider.md
@@ -11,7 +11,7 @@ Non-negotiables (see AGENTS.md for the rest):
 - Root views are **`Runnable`** or **`Window`**, never `Toplevel`.
 - Namespaces are split: `using Terminal.Gui.App;` / `.Views;` / `.ViewBase;` / `.Input;` … —
   the bare `using Terminal.Gui;` is gone.
-- **No `Clicked` event** — use `Accepting` (pre/cancelable) or `Accepted` (post). Use object
+- **No `Clicked` event** — use `Accepted` for side effects; `Accepting` only to cancel (`e.Handled = true`). Use object
   initializers (`new Button { Text = "OK" }`), not positional constructors.
 - **Layout is declarative** — `Pos.Center ()`, `Dim.Fill ()`; don't hardcode coordinates.
 - Dialogs: the **last button added is the default**; type-specific views expose `.Value`

--- a/templates/tui/.cursorrules
+++ b/templates/tui/.cursorrules
@@ -11,7 +11,7 @@ Non-negotiables (see AGENTS.md for the rest):
 - Root views are **`Runnable`** or **`Window`**, never `Toplevel`.
 - Namespaces are split: `using Terminal.Gui.App;` / `.Views;` / `.ViewBase;` / `.Input;` … —
   the bare `using Terminal.Gui;` is gone.
-- **No `Clicked` event** — use `Accepting` (pre/cancelable) or `Accepted` (post). Use object
+- **No `Clicked` event** — use `Accepted` for side effects; `Accepting` only to cancel (`e.Handled = true`). Use object
   initializers (`new Button { Text = "OK" }`), not positional constructors.
 - **Layout is declarative** — `Pos.Center ()`, `Dim.Fill ()`; don't hardcode coordinates.
 - Dialogs: the **last button added is the default**; type-specific views expose `.Value`

--- a/templates/tui/.windsurfrules
+++ b/templates/tui/.windsurfrules
@@ -11,7 +11,7 @@ Non-negotiables (see AGENTS.md for the rest):
 - Root views are **`Runnable`** or **`Window`**, never `Toplevel`.
 - Namespaces are split: `using Terminal.Gui.App;` / `.Views;` / `.ViewBase;` / `.Input;` … —
   the bare `using Terminal.Gui;` is gone.
-- **No `Clicked` event** — use `Accepting` (pre/cancelable) or `Accepted` (post). Use object
+- **No `Clicked` event** — use `Accepted` for side effects; `Accepting` only to cancel (`e.Handled = true`). Use object
   initializers (`new Button { Text = "OK" }`), not positional constructors.
 - **Layout is declarative** — `Pos.Center ()`, `Dim.Fill ()`; don't hardcode coordinates.
 - Dialogs: the **last button added is the default**; type-specific views expose `.Value`

--- a/templates/tui/AGENTS.md
+++ b/templates/tui/AGENTS.md
@@ -35,7 +35,7 @@ internal sealed class MainWindow : Window   // bordered root; use `Runnable` for
     {
         Title = "My App (Esc to quit)";
         Button b = new () { Text = "_OK", X = Pos.Center (), Y = Pos.Center () };
-        b.Accepting += (_, _) => App!.RequestStop ();
+        b.Accepted += (_, _) => App!.RequestStop ();
         Add (b);
     }
 }
@@ -51,7 +51,7 @@ internal sealed class MainWindow : Window   // bordered root; use `Runnable` for
 | `using Terminal.Gui;` | split namespaces: `Terminal.Gui.App` / `.Views` / `.ViewBase` / `.Drawing` / `.Input` / `.Configuration` |
 | `new Toplevel ()` | subclass `Runnable`, or use `Window` |
 | `new Button ("OK")` | `new Button { Text = "OK" }` (object initializers; no positional ctors) |
-| `button.Clicked += …` | `button.Accepting += (_, _) => …;` (no `Clicked` in v2) |
+| `button.Clicked += …` | `button.Accepted += (_, _) => …;` (no `Clicked` in v2) |
 | `view.Bounds` | `view.Viewport` |
 | `LayoutStyle.Computed` | removed — layout is always declarative via `Pos`/`Dim` |
 | `new RadioGroup (…)` | `new OptionSelector { … }` |
@@ -66,7 +66,7 @@ internal sealed class MainWindow : Window   // bordered root; use `Runnable` for
    (Enter-activated) — for both `Dialog` and `MessageBox`. Order them `Cancel … OK` so the
    affirmative action is last. Don't hand-set `IsDefault` unless you mean to override this.
 2. **`Accepted` vs `Accepting`.** `Accepting` is the pre-event (set `e.Handled = true` to
-   cancel); `Accepted` is the post-event for side effects. Use the one that matches intent.
+   cancel); `Accepted` is the post-event for side effects. Default to `Accepted`; reach for `Accepting` only to cancel.
 3. **Typed views expose `.Value`, not guessed names.** They implement `IValue<T>` —
    `datePicker.Value` (a `DateTime`), not `.Date`; subscribe `ValueChanged`/`ValueChanging`.
 4. **`AddCommand` is `protected`.** Register commands **inside** your `View` subclass, then

--- a/templates/tui/Program.cs
+++ b/templates/tui/Program.cs
@@ -74,9 +74,10 @@ public sealed class MainWindow : Runnable
             Y = Pos.Center () + 1
         };
 
-        // No `Clicked` in v2 — a view raises `Accepting` when activated (Enter/click/hotkey).
+        // No `Clicked` in v2 — use `Accepted` for side effects (it fires when the view is
+        // activated: Enter/click/hotkey). Use `Accepting` only to inspect/cancel (e.Handled = true).
         // `App!` is the running IApplication, reachable from any view in the tree.
-        increment.Accepting += (_, _) =>
+        increment.Accepted += (_, _) =>
         {
             _count++;
             _countLabel.Text = $"Count: {_count}";   // update state -> UI


### PR DESCRIPTION
Per the maintainer ruling that **`Accepted` is canonical for side effects** (`Accepting` only to cancel), this aligns the templates, which were using `Accepting` for side-effect handlers and so contradicted `ai-v2-primer.md`.

Changed across **both** templates:
- `Program.cs` — quit / increment handlers `Accepting` → `Accepted` (+ comments).
- `AGENTS.md` — the canonical-app snippet, the v1→v2 corrections-table example, and gotcha #2 now lead with `Accepted`.
- `.cursorrules` / `.windsurfrules` / `.aider.md` — the event bullet now says "use `Accepted` for side effects; `Accepting` only to cancel."

Verified: both templates build; the `--WithTests` headless test still passes (`InvokeCommand(Command.Accept)` fires the `Accepted` handler); the AGENTS.md snippet-compile guard still passes.